### PR TITLE
use defines to fix dimensions instead of setRotation()

### DIFF
--- a/examples/platformio basic examples/display_color_text/platformio.ini
+++ b/examples/platformio basic examples/display_color_text/platformio.ini
@@ -16,6 +16,7 @@ framework = arduino
 board_build.arduino.memory_type = qio_opi 
 board_build.partitions = default_16MB.csv
 board_upload.flash_size = 16MB
+monitor_speed = 115200
 lib_deps = bodmer/TFT_eSPI@^2.5.33
 build_flags = 
     -DBOARD_HAS_PSRAM # N16R8V has PSRAM
@@ -25,6 +26,8 @@ build_flags =
 	-D ST7789_DRIVER
 	-D TFT_RGB_ORDER=TFT_BGR # swap red and blue byte order
 	-D TFT_INVERSION_OFF
+	-D TFT_WIDTH=296  ;setting these will init the eSPI lib with correct dimensions
+	-D TFT_HEIGHT=240 ;setting these will init the eSPI lib with correct dimensions
 	-D TFT_MISO=8
 	-D TFT_MOSI=6
 	-D TFT_SCLK=7

--- a/examples/platformio basic examples/display_color_text/src/main.cpp
+++ b/examples/platformio basic examples/display_color_text/src/main.cpp
@@ -15,7 +15,8 @@ TFT_eSPI    tft = TFT_eSPI();
 void setup() {
   tft.init(TFT_BLACK);
   tft.initDMA();
-  tft.setRotation(3);
+  //setRotation is no longer necessary, as long as you define TFT_WIDTH and TFT_HEIGHT in platformio.ini
+  //tft.setRotation(3);
   tft.writecommand(TFT_MADCTL);
   tft.writedata(TFT_MAD_BGR | TFT_MAD_MV); //exchange red and blue bytes, and mirror x-coordinates
   //tft.fillScreen(TFT_BLACK);


### PR DESCRIPTION
defines in platformio.ini set width and height for display, and we no longer have the 24 pixel offset problem