### PR TITLE
Integrated hardware test example

### DIFF
--- a/examples/platformio basic examples/hardware_test/.gitignore
+++ b/examples/platformio basic examples/hardware_test/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/platformio basic examples/hardware_test/.vscode/extensions.json
+++ b/examples/platformio basic examples/hardware_test/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/library.properties
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/library.properties
@@ -1,0 +1,10 @@
+name=Fri3d Camp 2024 Badge
+version=0.0.1
+author=Fri3d Camp
+maintainer=Fri3d Camp <info@fri3d.be>
+sentence=Arduino library for the Fri3d Camp 2024 badge
+paragraph=Arduino library for the Fri3d Camp 2024 badge
+category=Other
+url=https://github.com/Fri3dCamp/badge_2024_arduino
+architectures=esp32
+depends=TFT_eSPI

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge24_battery_monitor.cpp
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge24_battery_monitor.cpp
@@ -1,0 +1,43 @@
+#include "Arduino.h"
+#include "Fri3dBadge24_battery_monitor.h"
+
+
+uint16_t Battery::m_raw_min = 1400; //1375 measured min
+uint16_t Battery::m_raw_max = 2330; //2364 measured max while charging, 2342 max after charging
+
+void Battery::set_raw_min(uint16_t& raw_min) {
+    m_raw_min = raw_min;
+}
+
+void Battery::set_raw_max(uint16_t& raw_max) {
+    m_raw_max = raw_max;
+}
+
+uint16_t Battery::read_raw() {
+    uint16_t raw_value = _read_raw();
+    log_d("Battery raw_value: %d", raw_value);
+    return raw_value;
+}
+
+uint8_t Battery::raw_to_percent(uint16_t& raw_value) {
+    uint16_t bound_value = max(min(raw_value, m_raw_max), m_raw_min);
+    uint8_t percent_value = map(bound_value, m_raw_min, m_raw_max, 0, 100);
+    return percent_value;
+}
+
+uint8_t Battery::read_percent() {
+    uint16_t raw_value = _read_raw();
+    uint8_t percent_value = raw_to_percent(raw_value);
+    log_d("Battery raw_value: %d -> %3d%%", raw_value, percent_value);
+    return percent_value;
+}
+
+uint16_t Battery::_read_raw(){
+    uint16_t max_raw=0;
+    for (int count=0; count<5; ++count)
+    {
+        uint16_t meas_raw= analogRead(BATTERY_PIN);
+        max_raw=max(max_raw,meas_raw);
+    }
+    return max_raw;
+}

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge24_battery_monitor.h
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge24_battery_monitor.h
@@ -1,0 +1,28 @@
+#ifndef Fri3dBadge24_Battery_h
+#define Fri3dBadge24_Battery_h
+
+#include <stdint.h>
+
+class Battery {
+    public:
+
+    static uint16_t m_raw_min;
+    static uint16_t m_raw_max;
+
+    static void set_raw_min(uint16_t& raw_min);
+    
+    static void set_raw_max(uint16_t& raw_max);
+    
+    static uint16_t read_raw();
+
+    static uint8_t raw_to_percent(uint16_t& raw_value);
+
+    static uint8_t read_percent();
+
+    private:
+    static const uint8_t BATTERY_PIN = 13;
+
+    static uint16_t _read_raw();
+};
+
+#endif

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_Button.cpp
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_Button.cpp
@@ -1,0 +1,74 @@
+#include "Fri3dBadge_Button.h"
+
+// initialize a Button object
+void Fri3d_Button::begin()
+{
+    pinMode(m_pin, m_mode);
+    m_state = readstate();
+    m_time = millis();
+    m_lastState = m_state;
+    m_changed = false;
+    m_lastChange = m_time;
+}
+
+// returns the state of the button, true if pressed, false if released.
+// does debouncing, captures and maintains times, previous state, etc.
+bool Fri3d_Button::read()
+{
+    uint32_t ms = millis();
+    bool pinVal =  readstate();
+    if (ms - m_lastChange < m_dbTime) {
+        m_changed = false;
+    }
+    else {
+        m_lastState = m_state;
+        m_state = pinVal;
+        m_changed = (m_state != m_lastState);
+        if (m_changed) m_lastChange = ms;
+    }
+    m_time = ms;
+    return m_state;
+}
+
+bool Fri3d_Button::readstate()
+{
+    bool state=m_lastState;
+    int value;
+
+    switch (m_buttontype)
+    {
+        case FRI3D_BUTTON_TYPE_DIGITAL:
+            state = digitalRead(m_pin);
+            break;
+
+        case FRI3D_BUTTON_TYPE_ANALOGUE_HIGH:
+            value = analogRead(m_pin); // sometimes there is a crash in AnalogRead, why ???
+            if (value > 3500) state=true;
+            if (value < 3400) state=false;
+            // in between : keep last state
+            break;
+
+        case FRI3D_BUTTON_TYPE_ANALOGUE_LOW:
+            value = analogRead(m_pin);  // sometimes there is a crash in AnalogRead, why ???
+            if (value < 500) state=true;
+            if (value > 600) state=false;
+            // in between : keep last state
+            break;
+
+        case FRI3D_BUTTON_TYPE_TOUCH:
+            value=0;
+            for (int count=0; count<5; ++count)
+            {
+                if (touchRead(m_pin)>45000) {
+                    ++value;
+                }
+            }
+            if (value == 0) state=false;
+            if (value == 5) state=true;
+            // in between : keep last state
+            break;
+    }
+    
+    if (m_invert) state = !state;
+    return state;
+}

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_Button.h
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_Button.h
@@ -1,0 +1,87 @@
+
+#ifndef FRI3DBADGE_BUTTON_H_INCLUDED
+#define FRI3DBADGE_BUTTON_H_INCLUDED
+
+// Based on 
+// Arduino Button Library
+// https://github.com/JChristensen/JC_Button
+// Copyright (C) 2018 by Jack Christensen and licensed under
+// GNU GPL v3.0, https://www.gnu.org/licenses/gpl.html
+
+#include <Arduino.h>
+
+enum Fri3DButton_type
+{
+ FRI3D_BUTTON_TYPE_DIGITAL=1,
+ FRI3D_BUTTON_TYPE_ANALOGUE_HIGH,
+ FRI3D_BUTTON_TYPE_ANALOGUE_LOW,
+ FRI3D_BUTTON_TYPE_TOUCH,
+};
+
+class Fri3d_Button
+{
+    public:
+        // Button(pin, dbTime, puEnable, invert) instantiates a button object.
+        //
+        // Required parameter:
+        // pin      The Arduino pin the button is connected to
+        //
+        // Optional parameters:
+        // dbTime   Debounce time in milliseconds (default 25ms)
+        // puEnable true to enable the AVR internal pullup resistor (default true)
+        // invert   true to interpret a low logic level as pressed (default true)
+        Fri3d_Button(Fri3DButton_type buttontype, uint8_t pin, uint32_t dbTime=25, uint8_t mode=INPUT_PULLUP, uint8_t invert=true)
+            : m_buttontype(buttontype), m_pin(pin), m_dbTime(dbTime), m_mode(mode), m_invert(invert) {}
+
+        // Initialize a Button object
+        void begin();
+
+        // Returns the state of the button, true if pressed, false if released.
+        // Does debouncing, captures and maintains times, previous state, etc.
+        // Call this function frequently to ensure the sketch is responsive to user input.
+        bool read();
+
+        // Returns true if the button state was pressed at the last call to read().
+        // Does not cause the button to be read.
+        bool isPressed() const {return m_state;}
+
+        // Returns true if the button state was released at the last call to read().
+        // Does not cause the button to be read.
+        bool isReleased() const {return !m_state;}
+
+        // These functions check the button state to see if it changed
+        // between the last two reads and return true or false accordingly.
+        // These functions do not cause the button to be read.
+        bool wasPressed() const {return m_state && m_changed;}
+        bool wasReleased() const {return !m_state && m_changed;}
+
+        // Returns true if the button state at the last call to read() was pressed,
+        // and has been in that state for at least the given number of milliseconds.
+        // This function does not cause the button to be read.
+        bool pressedFor(uint32_t ms) const {return m_state && m_time - m_lastChange >= ms;}
+
+        // Returns true if the button state at the last call to read() was released,
+        // and has been in that state for at least the given number of milliseconds.
+        // This function does not cause the button to be read.
+        bool releasedFor(uint32_t ms) const {return !m_state && m_time - m_lastChange >= ms;}
+
+        // Returns the time in milliseconds (from millis) that the button last
+        // changed state.
+        uint32_t lastChange() const {return m_lastChange;}
+
+    private:
+        bool readstate();
+
+        uint8_t m_pin;                  // arduino pin number connected to button
+        uint32_t m_dbTime;              // debounce time (ms)
+        uint8_t m_mode;                 // pinMode mode 
+        bool m_invert;                  // if true, interpret logic low as pressed, else interpret logic high as pressed
+        bool m_state = false;           // current button state, true=pressed
+        bool m_lastState = false;       // previous button state
+        bool m_changed = false;         // state changed since last read
+        uint32_t m_time = 0;            // time of current state (ms from millis)
+        uint32_t m_lastChange = 0;      // time of last state change (ms)
+        Fri3DButton_type m_buttontype;  
+};
+
+#endif

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_Buzzer.cpp
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_Buzzer.cpp
@@ -1,0 +1,27 @@
+#include "Fri3dBadge_Buzzer.h"
+#include "Arduino.h"
+
+Fri3dBadge_Buzzer::Fri3dBadge_Buzzer() {
+  volume = 255;
+  ledcSetup( CHANNEL_BUZZER, 3000, 8 );
+  ledcWrite( CHANNEL_BUZZER, 0 );
+  ledcAttachPin(PIN_BUZZER, CHANNEL_BUZZER);
+}
+
+void 
+Fri3dBadge_Buzzer::tone( int frequency, int duration ) {
+  ledcWriteTone( CHANNEL_BUZZER, frequency );
+  ledcWrite( CHANNEL_BUZZER, volume );
+  delay(duration);
+}
+
+void 
+Fri3dBadge_Buzzer::setVolume( int _volume ) {
+  volume = _volume;
+  ledcWrite( CHANNEL_BUZZER, volume );
+}
+
+void 
+Fri3dBadge_Buzzer::noTone(  ) {
+  ledcWrite( CHANNEL_BUZZER, 0 );
+}

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_Buzzer.h
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_Buzzer.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Fri3dBadge_pins.h"
+
+// library interface description
+class Fri3dBadge_Buzzer {
+public:
+  Fri3dBadge_Buzzer();
+  void tone( int frequency, int duration=0 );
+  void setVolume( int _volume );
+
+  void noTone();
+
+  private:
+    int volume;
+};
+

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_Joystick.cpp
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_Joystick.cpp
@@ -1,0 +1,19 @@
+#include "Fri3dBadge_Joystick.h"
+#include "Fri3dBadge_pins.h"
+
+Fri3dBadge_Joystick::Fri3dBadge_Joystick()
+{
+    pinMode(PIN_JOYSTICK_X,INPUT);
+    pinMode(PIN_JOYSTICK_Y,INPUT);
+    centerx = analogRead(PIN_JOYSTICK_X)-2048;
+    centery = analogRead(PIN_JOYSTICK_Y)-2048;
+}
+
+void 
+Fri3dBadge_Joystick::getXY(int *x,int *y) {
+  *x = analogRead(PIN_JOYSTICK_X)-2048;
+  *y = analogRead(PIN_JOYSTICK_Y)-2048;
+  if (abs(*x-centerx)<10) { *x=0; }
+  if (abs(*y-centery)<10) { *y=0; }
+}
+

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_Joystick.h
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_Joystick.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <Arduino.h>
+
+#define JOYSTICK_MAXVALUE 2048
+
+class Fri3dBadge_Joystick {
+public:
+  Fri3dBadge_Joystick();
+  void getXY(int *x,int *y);
+
+  private:
+    int centerx;
+    int centery;
+};

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_WSEN_ArduinoPlatform.cpp
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_WSEN_ArduinoPlatform.cpp
@@ -1,0 +1,155 @@
+/**
+ ***************************************************************************************************
+ * This file is part of WE Sensors SDK:
+ * https://www.we-online.com/sensors
+ *
+ * THE SOFTWARE INCLUDING THE SOURCE CODE IS PROVIDED “AS IS”. YOU ACKNOWLEDGE THAT WÜRTH ELEKTRONIK
+ * EISOS MAKES NO REPRESENTATIONS AND WARRANTIES OF ANY KIND RELATED TO, BUT NOT LIMITED
+ * TO THE NON-INFRINGEMENT OF THIRD PARTIES’ INTELLECTUAL PROPERTY RIGHTS OR THE
+ * MERCHANTABILITY OR FITNESS FOR YOUR INTENDED PURPOSE OR USAGE. WÜRTH ELEKTRONIK EISOS DOES NOT
+ * WARRANT OR REPRESENT THAT ANY LICENSE, EITHER EXPRESS OR IMPLIED, IS GRANTED UNDER ANY PATENT
+ * RIGHT, COPYRIGHT, MASK WORK RIGHT, OR OTHER INTELLECTUAL PROPERTY RIGHT RELATING TO ANY
+ * COMBINATION, MACHINE, OR PROCESS IN WHICH THE PRODUCT IS USED. INFORMATION PUBLISHED BY
+ * WÜRTH ELEKTRONIK EISOS REGARDING THIRD-PARTY PRODUCTS OR SERVICES DOES NOT CONSTITUTE A LICENSE
+ * FROM WÜRTH ELEKTRONIK EISOS TO USE SUCH PRODUCTS OR SERVICES OR A WARRANTY OR ENDORSEMENT
+ * THEREOF
+ *
+ * THIS SOURCE CODE IS PROTECTED BY A LICENSE.
+ * FOR MORE INFORMATION PLEASE CAREFULLY READ THE LICENSE AGREEMENT FILE LOCATED
+ * IN THE ROOT DIRECTORY OF THIS DRIVER PACKAGE.
+ *
+ * COPYRIGHT (c) 2019 Würth Elektronik eiSos GmbH & Co. KG
+ *
+ ***************************************************************************************************
+ **/
+
+#include "Fri3dBadge_WSEN_ArduinoPlatform.h"
+#include <Wire.h>
+
+int deviceAddress = 0;
+
+/**
+ * @brief  Initialize the I2C Interface
+ * @param  I2C address
+ * @retval Error Code
+ */
+
+int I2CInit(int address)
+{
+	uint32_t timeout = (uint32_t)(TIMEOUT_MS * 1000);  /* timeout in us */
+	
+    deviceAddress = address;
+	Wire.setTimeOut(timeout);
+    Wire.begin();
+	
+    return WE_SUCCESS;
+}
+
+
+int I2CDeInit(void)
+{
+    Wire.endTransmission(true);	/* end i2c transmission with stop = true, releasing the interface */
+    return WE_SUCCESS;
+}
+
+/**
+ * @brief  Set I2C bus Address
+ * @param  I2C address
+ * @retval Set Address
+ */
+
+void I2CSetAddress(int address) 
+{ 
+	deviceAddress = address; 
+}
+
+/**
+ * @brief   Read data starting from the addressed register
+ * @param  -RegAdr : register address to read from
+ *         -NumByteToRead : number of bytes to read
+ *         -pointer Data : address stores the data
+ * @retval Error Code
+ */
+
+int ReadReg(uint8_t RegAdr, int NumByteToRead, uint8_t *Data)
+{
+	if (0 == NumByteToRead)
+	{
+		return WE_FAIL;
+	}
+
+    Wire.beginTransmission(deviceAddress);
+    Wire.write(RegAdr);
+	Wire.endTransmission();
+	
+    int n = Wire.requestFrom(deviceAddress, NumByteToRead);	
+	if (n != NumByteToRead) /* also includes: if n == 0 */
+	{
+		return WE_FAIL;
+	}
+	
+    for (int i = 0; i < n; i++)
+    {
+        Data[i] = Wire.read();
+    }
+
+    return WE_SUCCESS;
+}
+
+/**
+ * @brief  Write data starting from the addressed register
+ * @param  -RegAdr : address to write in
+ *         -NumByteToWrite : number of bytes to write
+ *         -pointer Data : address of the data to be written
+ * @retval Error Code
+ */
+
+int WriteReg(uint8_t RegAdr, int NumByteToWrite, uint8_t *Data)
+{
+
+	if (0 == NumByteToWrite)
+	{
+		return WE_FAIL;
+	}
+
+    Wire.beginTransmission(deviceAddress);
+    Wire.write(RegAdr);
+	
+	for (int i = 0; i < NumByteToWrite; i++)
+    {
+        Wire.write(Data[i]);
+    }
+	
+	if (Wire.endTransmission()) /* slave ack or nack */
+    {
+        return WE_FAIL;
+    }
+
+    return WE_SUCCESS;
+}
+
+ /**
+ * @brief   Read data starting from the addressed register
+ * @param  -pointer Data : the address store the data
+ *         -NumByteToRead : number of bytes to read     
+ * @retval Error Code
+ */
+
+int I2C_read(uint8_t *data, int bytesToRead)
+{
+	Wire.beginTransmission(deviceAddress);
+    int n = Wire.requestFrom(deviceAddress, bytesToRead); // request Bytes
+	
+	if (n != bytesToRead) /* also includes: if n == 0 */
+	{
+		return WE_FAIL;
+	}	
+
+	for(int index = 0; index < bytesToRead; index++)
+	{
+		data[index] = Wire.read();
+	}
+    
+    return WE_SUCCESS;
+}
+/**         EOF         */

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_WSEN_ArduinoPlatform.h
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_WSEN_ArduinoPlatform.h
@@ -1,0 +1,64 @@
+/**
+ ***************************************************************************************************
+ * This file is part of WE Sensors SDK:
+ * https://www.we-online.com/sensors
+ *
+ * THE SOFTWARE INCLUDING THE SOURCE CODE IS PROVIDED “AS IS”. YOU ACKNOWLEDGE THAT WÜRTH ELEKTRONIK
+ * EISOS MAKES NO REPRESENTATIONS AND WARRANTIES OF ANY KIND RELATED TO, BUT NOT LIMITED
+ * TO THE NON-INFRINGEMENT OF THIRD PARTIES’ INTELLECTUAL PROPERTY RIGHTS OR THE
+ * MERCHANTABILITY OR FITNESS FOR YOUR INTENDED PURPOSE OR USAGE. WÜRTH ELEKTRONIK EISOS DOES NOT
+ * WARRANT OR REPRESENT THAT ANY LICENSE, EITHER EXPRESS OR IMPLIED, IS GRANTED UNDER ANY PATENT
+ * RIGHT, COPYRIGHT, MASK WORK RIGHT, OR OTHER INTELLECTUAL PROPERTY RIGHT RELATING TO ANY
+ * COMBINATION, MACHINE, OR PROCESS IN WHICH THE PRODUCT IS USED. INFORMATION PUBLISHED BY
+ * WÜRTH ELEKTRONIK EISOS REGARDING THIRD-PARTY PRODUCTS OR SERVICES DOES NOT CONSTITUTE A LICENSE
+ * FROM WÜRTH ELEKTRONIK EISOS TO USE SUCH PRODUCTS OR SERVICES OR A WARRANTY OR ENDORSEMENT
+ * THEREOF
+ *
+ * THIS SOURCE CODE IS PROTECTED BY A LICENSE.
+ * FOR MORE INFORMATION PLEASE CAREFULLY READ THE LICENSE AGREEMENT FILE LOCATED
+ * IN THE ROOT DIRECTORY OF THIS DRIVER PACKAGE.
+ *
+ * COPYRIGHT (c) 2023 Würth Elektronik eiSos GmbH & Co. KG
+ *
+ ***************************************************************************************************
+ **/
+
+#ifndef FRI3DBADGE_WSEN_ARDUINOPLATFORM_H
+#define FRI3DBADGE_WSEN_ARDUINOPLATFORM_H
+
+#define TIMEOUT_MS (uint16_t)100		/* 100ms */
+
+/**         Includes         **/
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <Arduino.h>
+#include <stdbool.h>
+
+#define WE_SUCCESS 0
+#define WE_FAIL -1
+
+//Use SDA1 and SCL1 on Arduino Due
+#if defined(__SAM3X8E__)
+#define Wire Wire1
+#endif
+
+/**         Functions definition         **/
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void I2CSetAddress(int address);
+int I2CInit(int address);
+int ReadReg(uint8_t RegAdr, int NumByteToRead, uint8_t *Data);
+int WriteReg(uint8_t RegAdr, int NumByteToWrite, uint8_t *Data);
+int I2C_read(uint8_t *data, int bytesToRead);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINOPLATFORM_H */

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_WSEN_ISDS.cpp
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_WSEN_ISDS.cpp
@@ -1,0 +1,516 @@
+/**
+ ***************************************************************************************************
+ * This file is part of WE Sensors SDK:
+ * https://www.we-online.com/sensors
+ *
+ * THE SOFTWARE INCLUDING THE SOURCE CODE IS PROVIDED “AS IS”. YOU ACKNOWLEDGE THAT WÜRTH ELEKTRONIK
+ * EISOS MAKES NO REPRESENTATIONS AND WARRANTIES OF ANY KIND RELATED TO, BUT NOT LIMITED
+ * TO THE NON-INFRINGEMENT OF THIRD PARTIES’ INTELLECTUAL PROPERTY RIGHTS OR THE
+ * MERCHANTABILITY OR FITNESS FOR YOUR INTENDED PURPOSE OR USAGE. WÜRTH ELEKTRONIK EISOS DOES NOT
+ * WARRANT OR REPRESENT THAT ANY LICENSE, EITHER EXPRESS OR IMPLIED, IS GRANTED UNDER ANY PATENT
+ * RIGHT, COPYRIGHT, MASK WORK RIGHT, OR OTHER INTELLECTUAL PROPERTY RIGHT RELATING TO ANY
+ * COMBINATION, MACHINE, OR PROCESS IN WHICH THE PRODUCT IS USED. INFORMATION PUBLISHED BY
+ * WÜRTH ELEKTRONIK EISOS REGARDING THIRD-PARTY PRODUCTS OR SERVICES DOES NOT CONSTITUTE A LICENSE
+ * FROM WÜRTH ELEKTRONIK EISOS TO USE SUCH PRODUCTS OR SERVICES OR A WARRANTY OR ENDORSEMENT
+ * THEREOF
+ *
+ * THIS SOURCE CODE IS PROTECTED BY A LICENSE.
+ * FOR MORE INFORMATION PLEASE CAREFULLY READ THE LICENSE AGREEMENT FILE LOCATED
+ * IN THE ROOT DIRECTORY OF THIS DRIVER PACKAGE.
+ *
+ * COPYRIGHT (c) 2023 Würth Elektronik eiSos GmbH & Co. KG
+ *
+ ***************************************************************************************************
+ **/
+
+#include "Fri3dBadge_WSEN_ISDS.h"
+#include <stdint.h>
+
+/**
+   @brief  Initialize the I2C Interface
+   @param  I2C address
+   @retval Error Code
+*/
+int Sensor_ISDS::init(int address)
+{
+    return I2CInit(address);
+}
+
+/**
+   @brief   Return the device ID for this sensor
+   @retval  Value of DEVICE_ID
+*/
+
+int Sensor_ISDS::get_DeviceID()
+{
+    uint8_t devID;
+
+    if (WE_SUCCESS == ISDS_getDeviceID(&devID))
+    {
+        return devID;
+    }
+	
+    return WE_FAIL;
+}
+
+/**
+   @brief  Set the output data rate 
+   @retval Error Code
+*/
+int Sensor_ISDS::select_ODR(int ODR)
+{
+    switch (ODR)
+    {
+        case 0:
+        {
+            if (WE_FAIL == ISDS_setFifoOutputDataRate(ISDS_fifoOdrOff))
+				{
+        return WE_FAIL;
+    }
+            break;
+        }
+
+        case 1:
+        {
+            if (WE_FAIL == ISDS_setFifoOutputDataRate(ISDS_fifoOdr12Hz5))
+				{
+        return WE_FAIL;
+    }
+            break;
+        }
+
+        case 2:
+        {
+            if (WE_FAIL == ISDS_setFifoOutputDataRate(ISDS_fifoOdr26Hz))
+				{
+        return WE_FAIL;
+    }
+            break;
+        }
+
+        case 3:
+        {
+            if (WE_FAIL == ISDS_setFifoOutputDataRate(ISDS_fifoOdr52Hz))
+				{
+        return WE_FAIL;
+    }
+            break;
+        }
+
+        case 4:
+        {
+            if (WE_FAIL == ISDS_setFifoOutputDataRate(ISDS_fifoOdr104Hz))
+				{
+        return WE_FAIL;
+    }
+            break;
+        }
+
+        case 5:
+        {
+            if (WE_FAIL == ISDS_setFifoOutputDataRate(ISDS_fifoOdr208Hz))
+				{
+        return WE_FAIL;
+    }
+            break;
+        }
+
+        case 6:
+        {
+            if (WE_FAIL == ISDS_setFifoOutputDataRate(ISDS_fifoOdr416Hz))
+				{
+        return WE_FAIL;
+    }
+            break;
+        }
+
+        case 7:
+        {
+            if (WE_FAIL == ISDS_setFifoOutputDataRate(ISDS_fifoOdr833Hz))
+				{
+        return WE_FAIL;
+    }
+            break;
+        }
+
+        case 8:
+        {
+            if (WE_FAIL == ISDS_setFifoOutputDataRate(ISDS_fifoOdr1k66Hz))
+				
+				{
+        return WE_FAIL;
+    }
+            break;
+        }
+
+        case 9:
+        {
+            if (WE_FAIL == ISDS_setFifoOutputDataRate(ISDS_fifoOdr3k33Hz))
+				{
+        return WE_FAIL;
+    }
+            break;
+        }
+
+        case 10:
+        {
+            if (WE_FAIL == ISDS_setFifoOutputDataRate(ISDS_fifoOdr6k66Hz))
+				{
+        return WE_FAIL;
+    }
+            break;
+        }
+
+        default:
+        {
+            return WE_FAIL;
+        }
+    }
+    return WE_SUCCESS;
+}
+
+/**
+   @brief   Perform the power-down 
+*/
+int Sensor_ISDS::power_down()
+{
+    if (WE_FAIL == ISDS_enableBlockDataUpdate(ISDS_disable))
+	{
+        return WE_FAIL;
+    }
+    if (WE_FAIL == ISDS_setAccOutputDataRate(ISDS_accOdrOff))
+	{
+        return WE_FAIL;
+    }
+    if (WE_FAIL == ISDS_setGyroOutputDataRate(ISDS_gyroOdrOff))
+	{
+        return WE_FAIL;
+    }
+	
+	return WE_SUCCESS;
+}
+
+/**
+   @brief   Configure a software reset procedure
+*/
+int Sensor_ISDS::SW_RESET()
+{
+    if (WE_FAIL == ISDS_softReset(ISDS_enable))
+	{
+        return WE_FAIL;
+    }
+	
+	return WE_SUCCESS;
+}
+
+/**
+   @brief   Set the mode (high performance, normal or low power)
+*/
+int Sensor_ISDS::set_Mode(int mode)
+{
+    if (WE_FAIL == ISDS_enableBlockDataUpdate(ISDS_enable))
+	{
+        return WE_FAIL;
+    }
+    if (WE_FAIL == ISDS_enableAutoIncrement(ISDS_enable))
+	{
+        return WE_FAIL;
+    }
+    
+    /* Accelerometer 16g range */
+    if (WE_FAIL == ISDS_setAccFullScale(ISDS_accFullScaleSixteenG))
+	{
+        return WE_FAIL;
+    }
+
+    /* Gyroscope 2000 dps range */
+    if (WE_FAIL == ISDS_setGyroFullScale(ISDS_gyroFullScale2000dps))
+	{
+        return WE_FAIL;
+    }
+
+    switch (mode)
+    {
+        case 2://high performance
+        {
+            if (WE_FAIL == ISDS_setAccOutputDataRate(ISDS_accOdr208Hz))
+			{
+				return WE_FAIL;
+			}
+			if (WE_FAIL == ISDS_setGyroOutputDataRate(ISDS_gyroOdr208Hz))
+			{
+				return WE_FAIL;
+			}
+			if (WE_FAIL == ISDS_disableAccHighPerformanceMode(ISDS_disable))
+			{
+				return WE_FAIL;
+			}
+			if (WE_FAIL == ISDS_disableGyroHighPerformanceMode(ISDS_disable))
+			{
+				return WE_FAIL;
+			}
+			break;   
+        }
+
+        case 1://normal
+        {
+            if (WE_FAIL == ISDS_setAccOutputDataRate(ISDS_accOdr208Hz))
+			{
+				return WE_FAIL;
+			}
+			if (WE_FAIL == ISDS_setGyroOutputDataRate(ISDS_gyroOdr208Hz))
+			{
+				return WE_FAIL;
+			}
+			if (WE_FAIL == ISDS_disableAccHighPerformanceMode(ISDS_enable))
+			{
+				return WE_FAIL;
+			}
+			if (WE_FAIL == ISDS_disableGyroHighPerformanceMode(ISDS_enable))
+			{
+				return WE_FAIL;
+			}
+            break;   
+		}
+        
+
+        case 0://low power
+        default:
+        {
+            if (WE_FAIL == ISDS_setAccOutputDataRate(ISDS_accOdr52Hz))
+			{
+				return WE_FAIL;
+			}
+			if (WE_FAIL == ISDS_setGyroOutputDataRate(ISDS_gyroOdr52Hz))
+			{
+				return WE_FAIL;
+			}
+			if (WE_FAIL == ISDS_disableAccHighPerformanceMode(ISDS_enable))
+			{
+				return WE_FAIL;
+			}
+			if (WE_FAIL == ISDS_disableGyroHighPerformanceMode(ISDS_enable))
+			{
+				return WE_FAIL;
+			}
+			break;
+        }
+    }
+	
+	return WE_SUCCESS;
+}
+
+/**
+   @brief   Check if new acceleration measurement is available 
+   @retval  Error Code
+*/
+int Sensor_ISDS::is_ACC_Ready_To_Read()
+{
+    ISDS_state_t drdy;
+    if (WE_FAIL == ISDS_isAccelerationDataReady(&drdy))
+    {
+        return WE_FAIL;
+    }
+    else
+    {
+        return drdy;
+    }
+}
+
+/**
+   @brief   Check if new gyroscope measurement is available 
+   @retval  Error Code
+*/
+int Sensor_ISDS::is_Gyro_Ready_To_Read()
+{
+    ISDS_state_t drdy;
+    if (WE_FAIL == ISDS_isGyroscopeDataReady(&drdy))
+    {
+        return WE_FAIL;
+    }
+    else
+    {
+        return drdy;
+    }
+}
+
+/**
+   @brief   Check if new temperature measurement is available 
+   @retval  Error Code
+*/
+int Sensor_ISDS::is_Temp_Ready()
+{
+    ISDS_state_t drdy;
+    if (WE_FAIL == ISDS_isTemperatureDataReady(&drdy))
+    {
+        return WE_FAIL;
+    }
+    else
+    {
+        return drdy;
+    }
+}
+
+int Sensor_ISDS::get_StatusRegister(ISDS_status_t *status)
+{
+
+    if (WE_FAIL == ISDS_getStatusRegister(status))
+    {
+        return WE_FAIL;
+    }
+    else
+    {
+        return WE_SUCCESS;
+    }
+}
+
+
+/**
+   @brief  Calculate the acceleration along the X-axis 
+   @retval Acceleration in mg
+*/
+int Sensor_ISDS::get_acceleration_X(int16_t *acc_x)
+{
+    int16_t val;
+    if (WE_FAIL == ISDS_getAccelerationX_int(&val))
+    {
+        return WE_FAIL;
+    }
+	
+    *acc_x = val;
+	return WE_SUCCESS;
+}
+
+/**
+   @brief  Calculate the acceleration along the Y-axis 
+   @retval Acceleration in mg
+*/
+int Sensor_ISDS::get_acceleration_Y(int16_t *acc_y)
+{
+    int16_t val;
+    if (WE_FAIL == ISDS_getAccelerationY_int(&val))
+    {
+        return WE_FAIL;
+    }
+	
+    *acc_y = val;
+	return WE_SUCCESS;
+}
+
+/**
+   @brief  Calculate the acceleration along the Z-axis 
+   @retval Acceleration in mg
+*/
+int Sensor_ISDS::get_acceleration_Z(int16_t *acc_z)
+{
+    int16_t val;
+    if (WE_FAIL == ISDS_getAccelerationZ_int(&val))
+    {
+        return WE_FAIL;
+    }
+	
+    *acc_z = val;
+	return WE_SUCCESS;
+}
+
+/**
+   @brief  Calculate the acceleration along all axes
+   @param  X x-axis acceleration
+   @param  Y y-axis acceleration
+   @param  Z z-axis acceleration
+   @retval Error Code
+*/
+int Sensor_ISDS::get_accelerations(int16_t* X, int16_t* Y, int16_t* Z)
+{
+    if (WE_FAIL == ISDS_getAccelerations_int(X,Y,Z))
+    {
+        return WE_FAIL;
+    }
+    return WE_SUCCESS;
+}
+
+/**
+   @brief  Calculate the angular along the X-axis 
+   @retval X-axis angular rate in [mdps]
+*/
+int Sensor_ISDS::get_angular_rate_X(int32_t *rate_x)
+{
+    int32_t val = 0;
+    /* Read gyroscope values (alternatively use ISDS_getAngularRates_int() to get values for all three axes in one go) */
+    if (WE_FAIL == ISDS_getAngularRateX_int(&val))
+    {
+        return WE_FAIL;
+    }
+    *rate_x = val;
+	return WE_SUCCESS;
+}
+
+/**
+   @brief  Calculate the angular along the Y-axis 
+   @retval y-axis angular rate in [mdps]
+*/
+int Sensor_ISDS::get_angular_rate_Y(int32_t *rate_y)
+{
+    int32_t val = 0;
+    /* Read gyroscope values (alternatively use ISDS_getAngularRates_int() to get values for all three axes in one go) */
+    if (WE_FAIL == ISDS_getAngularRateY_int(&val))
+    {
+        return WE_FAIL;
+    }
+	
+    *rate_y = val;
+	return WE_SUCCESS;
+}
+
+/**
+   @brief  Calculate the angular along the Z-axis 
+   @retval z-axis angular rate in [mdps]
+*/
+int Sensor_ISDS::get_angular_rate_Z(int32_t *rate_z)
+{
+    int32_t val = 0;
+    /* Read gyroscope values (alternatively use ISDS_getAngularRates_int() to get values for all three axes in one go) */
+    if (WE_FAIL == ISDS_getAngularRateZ_int(&val))
+    {
+        return WE_FAIL;
+    }
+	
+    *rate_z = val;
+	return WE_SUCCESS;
+
+}
+
+/**
+   @brief  Calculate the angular rates along all axes
+   @param  X x-axis angular rate
+   @param  Y y-axis angular rate
+   @param  Z z-axis angular rate
+   @retval Error Code
+*/
+int Sensor_ISDS::get_angular_rates(int32_t* X, int32_t* Y, int32_t* Z)
+{
+    if (ISDS_getAngularRates_int(X,Y,Z) == WE_FAIL)
+    {
+        return WE_FAIL;
+    }
+	
+    return WE_SUCCESS;
+}
+
+/**
+   @brief  Calculate the temperature;
+   @retval Temperature in [°C]
+*/
+int Sensor_ISDS::get_temperature(float *temp)
+{
+    int16_t val = 0;
+    if (WE_FAIL == ISDS_getTemperature_int(&val))
+    {
+        return WE_FAIL;
+    }
+
+    float f = (float)val;
+	*temp = f/100.0f;
+	return WE_SUCCESS;
+}
+

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_WSEN_ISDS.h
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_WSEN_ISDS.h
@@ -1,0 +1,65 @@
+/**
+ ***************************************************************************************************
+ * This file is part of WE Sensors SDK:
+ * https://www.we-online.com/sensors
+ *
+ * THE SOFTWARE INCLUDING THE SOURCE CODE IS PROVIDED “AS IS”. YOU ACKNOWLEDGE THAT WÜRTH ELEKTRONIK
+ * EISOS MAKES NO REPRESENTATIONS AND WARRANTIES OF ANY KIND RELATED TO, BUT NOT LIMITED
+ * TO THE NON-INFRINGEMENT OF THIRD PARTIES’ INTELLECTUAL PROPERTY RIGHTS OR THE
+ * MERCHANTABILITY OR FITNESS FOR YOUR INTENDED PURPOSE OR USAGE. WÜRTH ELEKTRONIK EISOS DOES NOT
+ * WARRANT OR REPRESENT THAT ANY LICENSE, EITHER EXPRESS OR IMPLIED, IS GRANTED UNDER ANY PATENT
+ * RIGHT, COPYRIGHT, MASK WORK RIGHT, OR OTHER INTELLECTUAL PROPERTY RIGHT RELATING TO ANY
+ * COMBINATION, MACHINE, OR PROCESS IN WHICH THE PRODUCT IS USED. INFORMATION PUBLISHED BY
+ * WÜRTH ELEKTRONIK EISOS REGARDING THIRD-PARTY PRODUCTS OR SERVICES DOES NOT CONSTITUTE A LICENSE
+ * FROM WÜRTH ELEKTRONIK EISOS TO USE SUCH PRODUCTS OR SERVICES OR A WARRANTY OR ENDORSEMENT
+ * THEREOF
+ *
+ * THIS SOURCE CODE IS PROTECTED BY A LICENSE.
+ * FOR MORE INFORMATION PLEASE CAREFULLY READ THE LICENSE AGREEMENT FILE LOCATED
+ * IN THE ROOT DIRECTORY OF THIS DRIVER PACKAGE.
+ *
+ * COPYRIGHT (c) 2023 Würth Elektronik eiSos GmbH & Co. KG
+ *
+ ***************************************************************************************************
+ **/
+
+#ifndef FRI3DBADGE_WSEN_ISDS_H
+#define FRI3DBADGE_WSEN_ISDS_H
+
+#include "Fri3dBadge_WSEN_ISDS_2536030320001.h"
+
+class Sensor_ISDS
+{
+
+public:
+    int init(int address);
+    int get_DeviceID();
+	
+    int power_down();
+    int SW_RESET();
+	
+    int select_ODR(int ODR);
+    int set_Mode(int mode);
+
+    int is_ACC_Ready_To_Read();
+    int is_Gyro_Ready_To_Read();
+    int is_Temp_Ready();
+	int get_StatusRegister(ISDS_status_t *status);
+	int get_Sensitivity(float *sens);
+		
+    int get_acceleration_X(int16_t *acc_x);
+    int get_acceleration_Y(int16_t *acc_y);
+    int get_acceleration_Z(int16_t *acc_z);
+
+	int get_angular_rate_X(int32_t *rate_x);
+    int get_angular_rate_Y(int32_t *rate_y);
+    int get_angular_rate_Z(int32_t *rate_z);
+	
+	int get_accelerations(int16_t *X, int16_t *Y, int16_t *Z);
+    int get_angular_rates(int32_t *X, int32_t *Y, int32_t *Z);
+    int get_temperature(float *temp);
+
+private:
+};
+
+#endif

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_WSEN_ISDS_2536030320001.c
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_WSEN_ISDS_2536030320001.c
@@ -1,0 +1,5923 @@
+/*
+ ***************************************************************************************************
+ * This file is part of Sensors SDK:
+ * https://www.we-online.com/sensors, https://github.com/WurthElektronik/Sensors-SDK_STM32
+ *
+ * THE SOFTWARE INCLUDING THE SOURCE CODE IS PROVIDED “AS IS”. YOU ACKNOWLEDGE THAT WÜRTH ELEKTRONIK
+ * EISOS MAKES NO REPRESENTATIONS AND WARRANTIES OF ANY KIND RELATED TO, BUT NOT LIMITED
+ * TO THE NON-INFRINGEMENT OF THIRD PARTIES’ INTELLECTUAL PROPERTY RIGHTS OR THE
+ * MERCHANTABILITY OR FITNESS FOR YOUR INTENDED PURPOSE OR USAGE. WÜRTH ELEKTRONIK EISOS DOES NOT
+ * WARRANT OR REPRESENT THAT ANY LICENSE, EITHER EXPRESS OR IMPLIED, IS GRANTED UNDER ANY PATENT
+ * RIGHT, COPYRIGHT, MASK WORK RIGHT, OR OTHER INTELLECTUAL PROPERTY RIGHT RELATING TO ANY
+ * COMBINATION, MACHINE, OR PROCESS IN WHICH THE PRODUCT IS USED. INFORMATION PUBLISHED BY
+ * WÜRTH ELEKTRONIK EISOS REGARDING THIRD-PARTY PRODUCTS OR SERVICES DOES NOT CONSTITUTE A LICENSE
+ * FROM WÜRTH ELEKTRONIK EISOS TO USE SUCH PRODUCTS OR SERVICES OR A WARRANTY OR ENDORSEMENT
+ * THEREOF
+ *
+ * THIS SOURCE CODE IS PROTECTED BY A LICENSE.
+ * FOR MORE INFORMATION PLEASE CAREFULLY READ THE LICENSE AGREEMENT FILE (license_terms_wsen_sdk.pdf)
+ * LOCATED IN THE ROOT DIRECTORY OF THIS DRIVER PACKAGE.
+ *
+ * COPYRIGHT (c) 2023 Würth Elektronik eiSos GmbH & Co. KG
+ *
+ ***************************************************************************************************
+ */
+
+/**
+ * @file
+ * @brief Driver file for the WSEN-ISDS sensor.
+ */
+
+#include "Fri3dBadge_WSEN_ISDS_2536030320001.h"
+
+#include <stdio.h>
+
+/**
+ * @brief Stores the current value of the accelerometer full scale parameter.
+ * The value is updated when calling ISDS_setAccFullScale() or
+ * ISDS_getAccFullScale().
+ *
+ */
+static ISDS_accFullScale_t currentAccFullScale = ISDS_accFullScaleTwoG;
+
+/**
+ * @brief Stores the current value of the gyroscope full scale parameter.
+ * The value is updated when calling ISDS_setGyroFullScale() or
+ * ISDS_getGyroFullScale().
+ *
+ */
+static ISDS_gyroFullScale_t currentGyroFullScale = ISDS_gyroFullScale250dps;
+
+/**
+ * @brief Read the device ID
+ *
+ * Expected value is ISDS_DEVICE_ID_VALUE.
+ *
+ * @param[out] deviceID The returned device ID.
+ * @retval Error code
+ */
+int8_t ISDS_getDeviceID(uint8_t *deviceID)
+{
+  return ReadReg(ISDS_DEVICE_ID_REG, 1, deviceID);
+}
+
+
+/* ISDS_FIFO_CTRL_1_REG */
+/* ISDS_FIFO_CTRL_2_REG */
+
+/**
+ * @brief Set the FIFO threshold of the sensor
+ * @param[in] threshold FIFO threshold (value between 0 and 127)
+ * @retval Error code
+ */
+int8_t ISDS_setFifoThreshold(uint16_t threshold)
+{
+  ISDS_fifoCtrl1_t fifoCtrl1;
+  ISDS_fifoCtrl2_t fifoCtrl2;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_2_REG, 1, (uint8_t *) &fifoCtrl2))
+  {
+    return WE_FAIL;
+  }
+
+  fifoCtrl1.fifoThresholdLsb = (uint8_t) (threshold & 0xFF);
+  fifoCtrl2.fifoThresholdMsb = (uint8_t) ((threshold >> 8) & 0x07);
+
+  if (WE_FAIL == WriteReg(ISDS_FIFO_CTRL_1_REG, 1, (uint8_t *) &fifoCtrl1))
+  {
+    return WE_FAIL;
+  }
+  return WriteReg(ISDS_FIFO_CTRL_2_REG, 1, (uint8_t *) &fifoCtrl2);
+}
+
+/**
+ * @brief Read the FIFO threshold of the sensor
+ * @param[out] threshold The returned FIFO threshold
+ * @retval Error code
+ */
+int8_t ISDS_getFifoThreshold(uint16_t *threshold)
+{
+  ISDS_fifoCtrl1_t fifoCtrl1;
+  ISDS_fifoCtrl2_t fifoCtrl2;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_1_REG, 1, (uint8_t *) &fifoCtrl1))
+  {
+    return WE_FAIL;
+  }
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_2_REG, 1, (uint8_t *) &fifoCtrl2))
+  {
+    return WE_FAIL;
+  }
+
+  *threshold = ((uint16_t) fifoCtrl1.fifoThresholdLsb) |
+               (((uint16_t) (fifoCtrl2.fifoThresholdMsb & 0x07)) << 8);
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable storage of temperature data in FIFO.
+ * @param[in] fifoTemp The storage of temperature data in FIFO enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableFifoTemperature(ISDS_state_t fifoTemp)
+{
+  ISDS_fifoCtrl2_t fifoCtrl2;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_2_REG, 1, (uint8_t *) &fifoCtrl2))
+  {
+    return WE_FAIL;
+  }
+
+  fifoCtrl2.enFifoTemperature = fifoTemp;
+
+  return WriteReg(ISDS_FIFO_CTRL_2_REG, 1, (uint8_t *) &fifoCtrl2);
+}
+
+/**
+ * @brief Check if storage of temperature data in FIFO is enabled.
+ * @param[out] fifoTemp The returned storage of temperature data in FIFO enable state
+ * @retval Error code
+ */
+int8_t ISDS_isFifoTemperatureEnabled(ISDS_state_t *fifoTemp)
+{
+  ISDS_fifoCtrl2_t fifoCtrl2;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_2_REG, 1, (uint8_t *) &fifoCtrl2))
+  {
+    return WE_FAIL;
+  }
+
+  *fifoTemp = (ISDS_state_t) fifoCtrl2.enFifoTemperature;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable storage of timestamp data in FIFO.
+ * @param[in] fifoTimestamp The storage of timestamp data in FIFO enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableFifoTimestamp(ISDS_state_t fifoTimestamp)
+{
+  ISDS_fifoCtrl2_t fifoCtrl2;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_2_REG, 1, (uint8_t *) &fifoCtrl2))
+  {
+    return WE_FAIL;
+  }
+
+  fifoCtrl2.enFifoTimestamp = fifoTimestamp;
+
+  return WriteReg(ISDS_FIFO_CTRL_2_REG, 1, (uint8_t *) &fifoCtrl2);
+}
+
+/**
+ * @brief Check if storage of timestamp data in FIFO is enabled.
+ * @param[out] fifoTimestamp The returned storage of timestamp data in FIFO enable state
+ * @retval Error code
+ */
+int8_t ISDS_isFifoTimestampEnabled(ISDS_state_t *fifoTimestamp)
+{
+  ISDS_fifoCtrl2_t fifoCtrl2;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_2_REG, 1, (uint8_t *) &fifoCtrl2))
+  {
+    return WE_FAIL;
+  }
+
+  *fifoTimestamp = (ISDS_state_t) fifoCtrl2.enFifoTimestamp;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_FIFO_CTRL_3_REG */
+
+/**
+ * @brief Set decimation of acceleration data in FIFO (second data set in FIFO)
+ * @param[in] decimation FIFO acceleration data decimation setting
+ * @retval Error code
+ */
+int8_t ISDS_setFifoAccDecimation(ISDS_fifoDecimation_t decimation)
+{
+  ISDS_fifoCtrl3_t fifoCtrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_3_REG, 1, (uint8_t *) &fifoCtrl3))
+  {
+    return WE_FAIL;
+  }
+
+  fifoCtrl3.fifoAccDecimation = (uint8_t) decimation;
+
+  return WriteReg(ISDS_FIFO_CTRL_3_REG, 1, (uint8_t *) &fifoCtrl3);
+}
+
+/**
+ * @brief Read decimation of acceleration data in FIFO (second data set in FIFO) setting
+ * @param[out] decimation The returned FIFO acceleration data decimation setting
+ * @retval Error code
+ */
+int8_t ISDS_getFifoAccDecimation(ISDS_fifoDecimation_t *decimation)
+{
+  ISDS_fifoCtrl3_t fifoCtrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_3_REG, 1, (uint8_t *) &fifoCtrl3))
+  {
+    return WE_FAIL;
+  }
+
+  *decimation = (ISDS_fifoDecimation_t) fifoCtrl3.fifoAccDecimation;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set decimation of gyroscope data in FIFO (first data set in FIFO)
+ * @param[in] decimation FIFO gyroscope data decimation setting
+ * @retval Error code
+ */
+int8_t ISDS_setFifoGyroDecimation(ISDS_fifoDecimation_t decimation)
+{
+  ISDS_fifoCtrl3_t fifoCtrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_3_REG, 1, (uint8_t *) &fifoCtrl3))
+  {
+    return WE_FAIL;
+  }
+
+  fifoCtrl3.fifoGyroDecimation = (uint8_t) decimation;
+
+  return WriteReg(ISDS_FIFO_CTRL_3_REG, 1, (uint8_t *) &fifoCtrl3);
+}
+
+/**
+ * @brief Read decimation of gyroscope data in FIFO (first data set in FIFO) setting
+ * @param[out] decimation The returned FIFO gyroscope data decimation setting
+ * @retval Error code
+ */
+int8_t ISDS_getFifoGyroDecimation(ISDS_fifoDecimation_t *decimation)
+{
+  ISDS_fifoCtrl3_t fifoCtrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_3_REG, 1, (uint8_t *) &fifoCtrl3))
+  {
+    return WE_FAIL;
+  }
+
+  *decimation = (ISDS_fifoDecimation_t) fifoCtrl3.fifoGyroDecimation;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_FIFO_CTRL_4_REG */
+
+/**
+ * @brief Set decimation of third data set in FIFO
+ * @param[in] decimation FIFO third data set decimation setting
+ * @retval Error code
+ */
+int8_t ISDS_setFifoDataset3Decimation(ISDS_fifoDecimation_t decimation)
+{
+  ISDS_fifoCtrl4_t fifoCtrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_4_REG, 1, (uint8_t *) &fifoCtrl4))
+  {
+    return WE_FAIL;
+  }
+
+  fifoCtrl4.fifoThirdDecimation = (uint8_t) decimation;
+
+  return WriteReg(ISDS_FIFO_CTRL_4_REG, 1, (uint8_t *) &fifoCtrl4);
+}
+
+/**
+ * @brief Read decimation of third data set in FIFO setting
+ * @param[out] decimation The returned FIFO third data set decimation setting
+ * @retval Error code
+ */
+int8_t ISDS_getFifoDataset3Decimation(ISDS_fifoDecimation_t *decimation)
+{
+  ISDS_fifoCtrl4_t fifoCtrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_4_REG, 1, (uint8_t *) &fifoCtrl4))
+  {
+    return WE_FAIL;
+  }
+
+  *decimation = (ISDS_fifoDecimation_t) fifoCtrl4.fifoThirdDecimation;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set decimation of fourth data set in FIFO
+ * @param[in] decimation FIFO fourth data set decimation setting
+ * @retval Error code
+ */
+int8_t ISDS_setFifoDataset4Decimation(ISDS_fifoDecimation_t decimation)
+{
+  ISDS_fifoCtrl4_t fifoCtrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_4_REG, 1, (uint8_t *) &fifoCtrl4))
+  {
+    return WE_FAIL;
+  }
+
+  fifoCtrl4.fifoFourthDecimation = (uint8_t) decimation;
+
+  return WriteReg(ISDS_FIFO_CTRL_4_REG, 1, (uint8_t *) &fifoCtrl4);
+}
+
+/**
+ * @brief Read decimation of fourth data set in FIFO setting
+ * @param[out] decimation The returned FIFO fourth data set decimation setting
+ * @retval Error code
+ */
+int8_t ISDS_getFifoDataset4Decimation(ISDS_fifoDecimation_t *decimation)
+{
+  ISDS_fifoCtrl4_t fifoCtrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_4_REG, 1, (uint8_t *) &fifoCtrl4))
+  {
+    return WE_FAIL;
+  }
+
+  *decimation = (ISDS_fifoDecimation_t) fifoCtrl4.fifoFourthDecimation;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable storage of MSB only (8-bit) in FIFO
+ * @param[in] onlyHighData MSB only enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableFifoOnlyHighData(ISDS_state_t onlyHighData)
+{
+  ISDS_fifoCtrl4_t fifoCtrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_4_REG, 1, (uint8_t *) &fifoCtrl4))
+  {
+    return WE_FAIL;
+  }
+
+  fifoCtrl4.enOnlyHighData = onlyHighData;
+
+  return WriteReg(ISDS_FIFO_CTRL_4_REG, 1, (uint8_t *) &fifoCtrl4);
+}
+
+/**
+ * @brief Check if storage of MSB only (8-bit) in FIFO is enabled
+ * @param[out] onlyHighData The returned MSB only enable state
+ * @retval Error code
+ */
+int8_t ISDS_isFifoOnlyHighDataEnabled(ISDS_state_t *onlyHighData)
+{
+  ISDS_fifoCtrl4_t fifoCtrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_4_REG, 1, (uint8_t *) &fifoCtrl4))
+  {
+    return WE_FAIL;
+  }
+
+  *onlyHighData = (ISDS_state_t) fifoCtrl4.enOnlyHighData;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable stop when FIFO threshold is reached
+ * @param[in] stopOnThreshold FIFO stop on threshold enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableFifoStopOnThreshold(ISDS_state_t stopOnThreshold)
+{
+  ISDS_fifoCtrl4_t fifoCtrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_4_REG, 1, (uint8_t *) &fifoCtrl4))
+  {
+    return WE_FAIL;
+  }
+
+  fifoCtrl4.enStopOnThreshold = stopOnThreshold;
+
+  return WriteReg(ISDS_FIFO_CTRL_4_REG, 1, (uint8_t *) &fifoCtrl4);
+}
+
+/**
+ * @brief Check if stop when FIFO threshold is reached is enabled
+ * @param[out] stopOnThreshold The returned FIFO stop on threshold enable state
+ * @retval Error code
+ */
+int8_t ISDS_isFifoStopOnThresholdEnabled(ISDS_state_t *stopOnThreshold)
+{
+  ISDS_fifoCtrl4_t fifoCtrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_4_REG, 1, (uint8_t *) &fifoCtrl4))
+  {
+    return WE_FAIL;
+  }
+
+  *stopOnThreshold = (ISDS_state_t) fifoCtrl4.enStopOnThreshold;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_FIFO_CTRL_5_REG */
+
+/**
+ * @brief Set the FIFO mode
+ * @param[in] fifoMode FIFO mode
+ * @retval Error code
+ */
+int8_t ISDS_setFifoMode(ISDS_fifoMode_t fifoMode)
+{
+  ISDS_fifoCtrl5_t fifoCtrl5;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_5_REG, 1, (uint8_t *) &fifoCtrl5))
+  {
+    return WE_FAIL;
+  }
+
+  fifoCtrl5.fifoMode = (uint8_t) fifoMode;
+
+  return WriteReg(ISDS_FIFO_CTRL_5_REG, 1, (uint8_t *) &fifoCtrl5);
+}
+
+/**
+ * @brief Read the FIFO mode
+ * @param[out] fifoMode The returned FIFO mode
+ * @retval Error code
+ */
+int8_t ISDS_getFifoMode(ISDS_fifoMode_t *fifoMode)
+{
+  ISDS_fifoCtrl5_t fifoCtrl5;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_5_REG, 1, (uint8_t *) &fifoCtrl5))
+  {
+    return WE_FAIL;
+  }
+
+  *fifoMode = (ISDS_fifoMode_t) fifoCtrl5.fifoMode;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the FIFO output data rate
+ * @param[in] fifoOdr FIFO output data rate
+ * @retval Error code
+ */
+int8_t ISDS_setFifoOutputDataRate(ISDS_fifoOutputDataRate_t fifoOdr)
+{
+  ISDS_fifoCtrl5_t fifoCtrl5;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_5_REG, 1, (uint8_t *) &fifoCtrl5))
+  {
+    return WE_FAIL;
+  }
+
+  fifoCtrl5.fifoOdr = (uint8_t) fifoOdr;
+
+  return WriteReg(ISDS_FIFO_CTRL_5_REG, 1, (uint8_t *) &fifoCtrl5);
+}
+
+/**
+ * @brief Read the FIFO output data rate
+ * @param[out] fifoOdr The returned FIFO output data rate
+ * @retval Error code
+ */
+int8_t ISDS_getFifoOutputDataRate(ISDS_fifoOutputDataRate_t *fifoOdr)
+{
+  ISDS_fifoCtrl5_t fifoCtrl5;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_CTRL_5_REG, 1, (uint8_t *) &fifoCtrl5))
+  {
+    return WE_FAIL;
+  }
+
+  *fifoOdr = (ISDS_fifoOutputDataRate_t) fifoCtrl5.fifoOdr;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_DRDY_PULSE_CFG_REG */
+
+/**
+ * @brief Enable pulsed data ready mode
+ * @param[in] dataReadyPulsed Data ready pulsed mode enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableDataReadyPulsed(ISDS_state_t dataReadyPulsed)
+{
+  ISDS_dataReadyPulseCfg_t dataReadyPulseCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_DRDY_PULSE_CFG_REG, 1, (uint8_t *) &dataReadyPulseCfg))
+  {
+    return WE_FAIL;
+  }
+
+  dataReadyPulseCfg.enDataReadyPulsed = (uint8_t) dataReadyPulsed;
+
+  return WriteReg(ISDS_DRDY_PULSE_CFG_REG, 1, (uint8_t *) &dataReadyPulseCfg);
+}
+
+/**
+ * @brief Check if pulsed data ready mode is enabled
+ * @param[out] dataReadyPulsed The returned data ready pulsed mode enable state
+ * @retval Error code
+ */
+int8_t ISDS_isDataReadyPulsedEnabled(ISDS_state_t *dataReadyPulsed)
+{
+  ISDS_dataReadyPulseCfg_t dataReadyPulseCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_DRDY_PULSE_CFG_REG, 1, (uint8_t *) &dataReadyPulseCfg))
+  {
+    return WE_FAIL;
+  }
+
+  *dataReadyPulsed = (ISDS_state_t) dataReadyPulseCfg.enDataReadyPulsed;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_INT0_CTRL_REG */
+
+/**
+ * @brief Enable/disable the acceleration data ready interrupt on INT_0
+ * @param[in] int0AccDataReady Acceleration data ready interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableAccDataReadyINT0(ISDS_state_t int0AccDataReady)
+{
+  ISDS_int0Ctrl_t int0Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  int0Ctrl.int0AccDataReady = (uint8_t) int0AccDataReady;
+
+  return WriteReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl);
+}
+
+/**
+ * @brief Check if the acceleration data ready interrupt on INT_0 is enabled
+ * @param[out] int0AccDataReady The returned acceleration data ready interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isAccDataReadyINT0Enabled(ISDS_state_t *int0AccDataReady)
+{
+  ISDS_int0Ctrl_t int0Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  *int0AccDataReady = (ISDS_state_t) int0Ctrl.int0AccDataReady;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the gyroscope data ready interrupt on INT_0
+ * @param[in] int0GyroDataReady Gyroscope data ready interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableGyroDataReadyINT0(ISDS_state_t int0GyroDataReady)
+{
+  ISDS_int0Ctrl_t int0Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  int0Ctrl.int0GyroDataReady = (uint8_t) int0GyroDataReady;
+
+  return WriteReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl);
+}
+
+/**
+ * @brief Check if the gyroscope data ready interrupt on INT_0 is enabled
+ * @param[out] int0GyroDataReady The returned gyroscope data ready interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isGyroDataReadyINT0Enabled(ISDS_state_t *int0GyroDataReady)
+{
+  ISDS_int0Ctrl_t int0Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  *int0GyroDataReady = (ISDS_state_t) int0Ctrl.int0GyroDataReady;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the boot status interrupt on INT_0
+ * @param[in] int0BootStatus Boot status interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableBootStatusINT0(ISDS_state_t int0BootStatus)
+{
+  ISDS_int0Ctrl_t int0Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  int0Ctrl.int0Boot = (uint8_t) int0BootStatus;
+
+  return WriteReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl);
+}
+
+/**
+ * @brief Check if the boot status interrupt on INT_0 is enabled
+ * @param[out] int0BootStatus The returned boot status interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isBootStatusINT0Enabled(ISDS_state_t *int0BootStatus)
+{
+  ISDS_int0Ctrl_t int0Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  *int0BootStatus = (ISDS_state_t) int0Ctrl.int0Boot;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the FIFO threshold reached interrupt on INT_0
+ * @param[in] int0FifoThreshold FIFO threshold reached interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableFifoThresholdINT0(ISDS_state_t int0FifoThreshold)
+{
+  ISDS_int0Ctrl_t int0Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  int0Ctrl.int0FifoThreshold = (uint8_t) int0FifoThreshold;
+
+  return WriteReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl);
+}
+
+/**
+ * @brief Check if the FIFO threshold reached interrupt on INT_0 is enabled
+ * @param[out] int0FifoThreshold The returned FIFO threshold reached interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isFifoThresholdINT0Enabled(ISDS_state_t *int0FifoThreshold)
+{
+  ISDS_int0Ctrl_t int0Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  *int0FifoThreshold = (ISDS_state_t) int0Ctrl.int0FifoThreshold;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the FIFO overrun interrupt on INT_0
+ * @param[in] int0FifoOverrun FIFO overrun interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableFifoOverrunINT0(ISDS_state_t int0FifoOverrun)
+{
+  ISDS_int0Ctrl_t int0Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  int0Ctrl.int0FifoOverrun = (uint8_t) int0FifoOverrun;
+
+  return WriteReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl);
+}
+
+/**
+ * @brief Check if the FIFO overrun interrupt on INT_0 is enabled
+ * @param[out] int0FifoOverrun The returned FIFO overrun interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isFifoOverrunINT0Enabled(ISDS_state_t *int0FifoOverrun)
+{
+  ISDS_int0Ctrl_t int0Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  *int0FifoOverrun = (ISDS_state_t) int0Ctrl.int0FifoOverrun;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the FIFO full interrupt on INT_0
+ * @param[in] int0FifoFull FIFO full interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableFifoFullINT0(ISDS_state_t int0FifoFull)
+{
+  ISDS_int0Ctrl_t int0Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  int0Ctrl.int0FifoFull = (uint8_t) int0FifoFull;
+
+  return WriteReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl);
+}
+
+/**
+ * @brief Check if the FIFO full interrupt on INT_0 is enabled
+ * @param[out] int0FifoFull The returned FIFO full interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isFifoFullINT0Enabled(ISDS_state_t *int0FifoFull)
+{
+  ISDS_int0Ctrl_t int0Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT0_CTRL_REG, 1, (uint8_t *) &int0Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  *int0FifoFull = (ISDS_state_t) int0Ctrl.int0FifoFull;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_INT1_CTRL_REG */
+
+/**
+ * @brief Enable/disable the acceleration data ready interrupt on INT_1
+ * @param[in] int1AccDataReady Acceleration data ready interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableAccDataReadyINT1(ISDS_state_t int1AccDataReady)
+{
+  ISDS_int1Ctrl_t int1Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  int1Ctrl.int1AccDataReady = (uint8_t) int1AccDataReady;
+
+  return WriteReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl);
+}
+
+/**
+ * @brief Check if the acceleration data ready interrupt on INT_1 is enabled
+ * @param[out] int1AccDataReady The returned acceleration data ready interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isAccDataReadyINT1Enabled(ISDS_state_t *int1AccDataReady)
+{
+  ISDS_int1Ctrl_t int1Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  *int1AccDataReady = (ISDS_state_t) int1Ctrl.int1AccDataReady;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the gyroscope data ready interrupt on INT_1
+ * @param[in] int1GyroDataReady Gyroscope data ready interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableGyroDataReadyINT1(ISDS_state_t int1GyroDataReady)
+{
+  ISDS_int1Ctrl_t int1Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  int1Ctrl.int1GyroDataReady = (uint8_t) int1GyroDataReady;
+
+  return WriteReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl);
+}
+
+/**
+ * @brief Check if the gyroscope data ready interrupt on INT_1 is enabled
+ * @param[out] int1GyroDataReady The returned gyroscope data ready interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isGyroDataReadyINT1Enabled(ISDS_state_t *int1GyroDataReady)
+{
+  ISDS_int1Ctrl_t int1Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  *int1GyroDataReady = (ISDS_state_t) int1Ctrl.int1GyroDataReady;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the temperature data ready interrupt on INT_1
+ * @param[in] int1TempDataReady Temperature data ready interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableTemperatureDataReadyINT1(ISDS_state_t int1TempDataReady)
+{
+  ISDS_int1Ctrl_t int1Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  int1Ctrl.int1TempDataReady = (uint8_t) int1TempDataReady;
+
+  return WriteReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl);
+}
+
+/**
+ * @brief Check if the temperature data ready interrupt on INT_1 is enabled
+ * @param[out] int1TempDataReady The returned temperature data ready interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isTemperatureDataReadyINT1Enabled(ISDS_state_t *int1TempDataReady)
+{
+  ISDS_int1Ctrl_t int1Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  *int1TempDataReady = (ISDS_state_t) int1Ctrl.int1TempDataReady;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the FIFO threshold reached interrupt on INT_1
+ * @param[in] int1FifoThreshold FIFO threshold reached interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableFifoThresholdINT1(ISDS_state_t int1FifoThreshold)
+{
+  ISDS_int1Ctrl_t int1Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  int1Ctrl.int1FifoThreshold = (uint8_t) int1FifoThreshold;
+
+  return WriteReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl);
+}
+
+/**
+ * @brief Check if the FIFO threshold reached interrupt on INT_1 is enabled
+ * @param[out] int1FifoThreshold The returned FIFO threshold reached interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isFifoThresholdINT1Enabled(ISDS_state_t *int1FifoThreshold)
+{
+  ISDS_int1Ctrl_t int1Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  *int1FifoThreshold = (ISDS_state_t) int1Ctrl.int1FifoThreshold;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the FIFO overrun interrupt on INT_1
+ * @param[in] int1FifoOverrun FIFO overrun interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableFifoOverrunINT1(ISDS_state_t int1FifoOverrun)
+{
+  ISDS_int1Ctrl_t int1Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  int1Ctrl.int1FifoOverrun = (uint8_t) int1FifoOverrun;
+
+  return WriteReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl);
+}
+
+/**
+ * @brief Check if the FIFO overrun interrupt on INT_1 is enabled
+ * @param[out] int1FifoOverrun The returned FIFO overrun interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isFifoOverrunINT1Enabled(ISDS_state_t *int1FifoOverrun)
+{
+  ISDS_int1Ctrl_t int1Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  *int1FifoOverrun = (ISDS_state_t) int1Ctrl.int1FifoOverrun;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the FIFO full interrupt on INT_1
+ * @param[in] int1FifoFull FIFO full interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableFifoFullINT1(ISDS_state_t int1FifoFull)
+{
+  ISDS_int1Ctrl_t int1Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  int1Ctrl.int1FifoFull = (uint8_t) int1FifoFull;
+
+  return WriteReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl);
+}
+
+/**
+ * @brief Check if the FIFO full interrupt on INT_1 is enabled
+ * @param[out] int1FifoFull The returned FIFO full interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isFifoFullINT1Enabled(ISDS_state_t *int1FifoFull)
+{
+  ISDS_int1Ctrl_t int1Ctrl;
+
+  if (WE_FAIL == ReadReg(ISDS_INT1_CTRL_REG, 1, (uint8_t *) &int1Ctrl))
+  {
+    return WE_FAIL;
+  }
+
+  *int1FifoFull = (ISDS_state_t) int1Ctrl.int1FifoFull;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_DEVICE_ID_REG */
+
+
+/* ISDS_CTRL_1_REG */
+
+/**
+ * @brief Set the accelerometer analog chain bandwidth
+ * @param[in] bandwidth Accelerometer analog chain bandwidth
+ * @retval Error code
+ */
+int8_t ISDS_setAccAnalogChainBandwidth(ISDS_accAnalogChainBandwidth_t bandwidth)
+{
+  ISDS_ctrl1_t ctrl1;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_1_REG, 1, (uint8_t *) &ctrl1))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl1.accAnalogBandwidth = bandwidth;
+
+  return WriteReg(ISDS_CTRL_1_REG, 1, (uint8_t *) &ctrl1);
+}
+
+/**
+ * @brief Read the accelerometer analog chain bandwidth
+ * @param[out] bandwidth The returned accelerometer analog chain bandwidth
+ * @retval Error code
+ */
+int8_t ISDS_getAccAnalogChainBandwidth(ISDS_accAnalogChainBandwidth_t *bandwidth)
+{
+  ISDS_ctrl1_t ctrl1;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_1_REG, 1, (uint8_t *) &ctrl1))
+  {
+    return WE_FAIL;
+  }
+
+  *bandwidth = (ISDS_accAnalogChainBandwidth_t) ctrl1.accAnalogBandwidth;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the accelerometer digital LPF (LPF1) bandwidth
+ * @param[in] bandwidth Accelerometer digital LPF (LPF1) bandwidth
+ * @retval Error code
+ */
+int8_t ISDS_setAccDigitalLpfBandwidth(ISDS_accDigitalLpfBandwidth_t bandwidth)
+{
+  ISDS_ctrl1_t ctrl1;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_1_REG, 1, (uint8_t *) &ctrl1))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl1.accDigitalBandwidth = bandwidth;
+
+  return WriteReg(ISDS_CTRL_1_REG, 1, (uint8_t *) &ctrl1);
+}
+
+/**
+ * @brief Read the accelerometer digital LPF (LPF1) bandwidth
+ * @param[out] bandwidth The returned accelerometer digital LPF (LPF1) bandwidth
+ * @retval Error code
+ */
+int8_t ISDS_getAccDigitalLpfBandwidth(ISDS_accDigitalLpfBandwidth_t *bandwidth)
+{
+  ISDS_ctrl1_t ctrl1;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_1_REG, 1, (uint8_t *) &ctrl1))
+  {
+    return WE_FAIL;
+  }
+
+  *bandwidth = (ISDS_accDigitalLpfBandwidth_t) ctrl1.accDigitalBandwidth;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the accelerometer full scale
+ * @param[in] fullScale Accelerometer full scale
+ * @retval Error code
+ */
+int8_t ISDS_setAccFullScale(ISDS_accFullScale_t fullScale)
+{
+  ISDS_ctrl1_t ctrl1;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_1_REG, 1, (uint8_t *) &ctrl1))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl1.accFullScale = fullScale;
+
+  int8_t errCode = WriteReg(ISDS_CTRL_1_REG, 1, (uint8_t *) &ctrl1);
+
+  /* Store current full scale value to allow convenient conversion of sensor readings */
+  if (WE_SUCCESS == errCode)
+  {
+    currentAccFullScale = fullScale;
+  }
+
+  return errCode;
+}
+
+/**
+ * @brief Read the accelerometer full scale
+ * @param[out] fullScale The returned accelerometer full scale
+ * @retval Error code
+ */
+int8_t ISDS_getAccFullScale(ISDS_accFullScale_t *fullScale)
+{
+  ISDS_ctrl1_t ctrl1;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_1_REG, 1, (uint8_t *) &ctrl1))
+  {
+    return WE_FAIL;
+  }
+
+  *fullScale = (ISDS_accFullScale_t) ctrl1.accFullScale;
+
+  /* Store current full scale value to allow convenient conversion of sensor readings */
+  currentAccFullScale = *fullScale;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the accelerometer output data rate
+ * @param[in] odr Output data rate
+ * @retval Error code
+ */
+int8_t ISDS_setAccOutputDataRate(ISDS_accOutputDataRate_t odr)
+{
+  ISDS_ctrl1_t ctrl1;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_1_REG, 1, (uint8_t *) &ctrl1))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl1.accOutputDataRate = odr;
+
+  return WriteReg(ISDS_CTRL_1_REG, 1, (uint8_t *) &ctrl1);
+}
+
+/**
+ * @brief Read the accelerometer output data rate
+ * @param[out] odr The returned output data rate
+ * @retval Error code
+ */
+int8_t ISDS_getAccOutputDataRate(ISDS_accOutputDataRate_t *odr)
+{
+  ISDS_ctrl1_t ctrl1;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_1_REG, 1, (uint8_t *) &ctrl1))
+  {
+    return WE_FAIL;
+  }
+
+  *odr = (ISDS_accOutputDataRate_t) ctrl1.accOutputDataRate;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_CTRL_2_REG */
+
+/**
+ * @brief Set the gyroscope full scale
+ * @param[in] fullScale gyroscope full scale
+ * @retval Error code
+ */
+int8_t ISDS_setGyroFullScale(ISDS_gyroFullScale_t fullScale)
+{
+  ISDS_ctrl2_t ctrl2;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_2_REG, 1, (uint8_t *) &ctrl2))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl2.gyroFullScale = fullScale;
+
+  int8_t errCode = WriteReg(ISDS_CTRL_2_REG, 1, (uint8_t *) &ctrl2);
+
+  /* Store current full scale value to allow convenient conversion of sensor readings */
+  if (WE_SUCCESS == errCode)
+  {
+    currentGyroFullScale = fullScale;
+  }
+
+  return errCode;
+}
+
+/**
+ * @brief Read the gyroscope full scale
+ * @param[out] fullScale The returned gyroscope full scale
+ * @retval Error code
+ */
+int8_t ISDS_getGyroFullScale(ISDS_gyroFullScale_t *fullScale)
+{
+  ISDS_ctrl2_t ctrl2;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_2_REG, 1, (uint8_t *) &ctrl2))
+  {
+    return WE_FAIL;
+  }
+
+  *fullScale = (ISDS_gyroFullScale_t) ctrl2.gyroFullScale;
+
+  /* Store current full scale value to allow convenient conversion of sensor readings */
+  currentGyroFullScale = *fullScale;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the gyroscope output data rate
+ * @param[in] odr Output data rate
+ * @retval Error code
+ */
+int8_t ISDS_setGyroOutputDataRate(ISDS_gyroOutputDataRate_t odr)
+{
+  ISDS_ctrl2_t ctrl2;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_2_REG, 1, (uint8_t *) &ctrl2))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl2.gyroOutputDataRate = odr;
+
+  return WriteReg(ISDS_CTRL_2_REG, 1, (uint8_t *) &ctrl2);
+}
+
+/**
+ * @brief Read the gyroscope output data rate
+ * @param[out] odr The returned output data rate.
+ * @retval Error code
+ */
+int8_t ISDS_getGyroOutputDataRate(ISDS_gyroOutputDataRate_t *odr)
+{
+  ISDS_ctrl2_t ctrl2;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_2_REG, 1, (uint8_t *) &ctrl2))
+  {
+    return WE_FAIL;
+  }
+
+  *odr = (ISDS_gyroOutputDataRate_t) ctrl2.gyroOutputDataRate;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_CTRL_3_REG */
+
+/**
+ * @brief Set software reset [enabled, disabled]
+ * @param[in] swReset Software reset state
+ * @retval Error code
+ */
+int8_t ISDS_softReset(ISDS_state_t swReset)
+{
+  ISDS_ctrl3_t ctrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl3.softReset = swReset;
+
+  return WriteReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3);
+}
+
+/**
+ * @brief Read the software reset state [enabled, disabled]
+ * @param[out] swReset The returned software reset state
+ * @retval Error code
+ */
+int8_t ISDS_getSoftResetState(ISDS_state_t *swReset)
+{
+  ISDS_ctrl3_t ctrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3))
+  {
+    return WE_FAIL;
+  }
+
+  *swReset = (ISDS_state_t) ctrl3.softReset;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable auto increment mode
+ * @param[in] autoIncr Auto increment mode enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableAutoIncrement(ISDS_state_t autoIncr)
+{
+  ISDS_ctrl3_t ctrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl3.autoAddIncr = autoIncr;
+
+  return WriteReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3);
+}
+
+/**
+ * @brief Read the auto increment mode state
+ * @param[out] autoIncr The returned auto increment mode enable state
+ * @retval Error code
+ */
+int8_t ISDS_isAutoIncrementEnabled(ISDS_state_t *autoIncr)
+{
+  ISDS_ctrl3_t ctrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3))
+  {
+    return WE_FAIL;
+  }
+
+  *autoIncr = (ISDS_state_t) ctrl3.autoAddIncr;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the SPI serial interface mode
+ * @param[in] spiMode SPI serial interface mode
+ * @retval Error code
+ */
+int8_t ISDS_setSpiMode(ISDS_spiMode_t spiMode)
+{
+  ISDS_ctrl3_t ctrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl3.spiMode = spiMode;
+
+  return WriteReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3);
+}
+
+/**
+ * @brief Read the SPI serial interface mode
+ * @param[out] spiMode The returned SPI serial interface mode
+ * @retval Error code
+ */
+int8_t ISDS_getSpiMode(ISDS_spiMode_t *spiMode)
+{
+  ISDS_ctrl3_t ctrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3))
+  {
+    return WE_FAIL;
+  }
+
+  *spiMode = (ISDS_spiMode_t) ctrl3.spiMode;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the interrupt pin type [push-pull/open-drain]
+ * @param[in] pinType Interrupt pin type
+ * @retval Error code
+ */
+int8_t ISDS_setInterruptPinType(ISDS_interruptPinConfig_t pinType)
+{
+  ISDS_ctrl3_t ctrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl3.intPinConf = pinType;
+
+  return WriteReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3);
+}
+
+/**
+ * @brief Read the interrupt pin type [push-pull/open-drain]
+ * @param[out] pinType The returned interrupt pin type
+ * @retval Error code
+ */
+int8_t ISDS_getInterruptPinType(ISDS_interruptPinConfig_t *pinType)
+{
+  ISDS_ctrl3_t ctrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3))
+  {
+    return WE_FAIL;
+  }
+
+  *pinType = (ISDS_state_t) ctrl3.intPinConf;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the interrupt active level [active high/active low]
+ * @param[in] level Interrupt active level
+ * @retval Error code
+ */
+int8_t ISDS_setInterruptActiveLevel(ISDS_interruptActiveLevel_t level)
+{
+  ISDS_ctrl3_t ctrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl3.intActiveLevel = level;
+
+  return WriteReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3);
+}
+
+/**
+ * @brief Read the interrupt active level
+ * @param[out] level The returned interrupt active level
+ * @retval Error code
+ */
+int8_t ISDS_getInterruptActiveLevel(ISDS_interruptActiveLevel_t *level)
+{
+  ISDS_ctrl3_t ctrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3))
+  {
+    return WE_FAIL;
+  }
+
+  *level = (ISDS_state_t) ctrl3.intActiveLevel;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable block data update mode
+ * @param[in] bdu Block data update enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableBlockDataUpdate(ISDS_state_t bdu)
+{
+  ISDS_ctrl3_t ctrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl3.blockDataUpdate = bdu;
+
+  return WriteReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3);
+}
+
+/**
+ * @brief Read the block data update state
+ * @param[out] bdu The returned block data update enable state
+ * @retval Error code
+ */
+int8_t ISDS_isBlockDataUpdateEnabled(ISDS_state_t *bdu)
+{
+  ISDS_ctrl3_t ctrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3))
+  {
+    return WE_FAIL;
+  }
+
+  *bdu = (ISDS_state_t) ctrl3.blockDataUpdate;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief (Re)boot the device [enabled, disabled]
+ * @param[in] reboot Reboot state
+ * @retval Error code
+ */
+int8_t ISDS_reboot(ISDS_state_t reboot)
+{
+  ISDS_ctrl3_t ctrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl3.boot = reboot;
+
+  return WriteReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3);
+}
+
+/**
+ * @brief Read the reboot state
+ * @param[out] rebooting The returned reboot state
+ * @retval Error code
+ */
+int8_t ISDS_isRebooting(ISDS_state_t *rebooting)
+{
+  ISDS_ctrl3_t ctrl3;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_3_REG, 1, (uint8_t *) &ctrl3))
+  {
+    return WE_FAIL;
+  }
+
+  *rebooting = (ISDS_state_t) ctrl3.boot;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_CTRL_4_REG */
+
+/**
+ * @brief Enable gyroscope digital LPF1
+ * @param[in] enable Gyroscope digital LPF1 enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableGyroDigitalLpf1(ISDS_state_t enable)
+{
+  ISDS_ctrl4_t ctrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl4.enGyroLPF1 = enable;
+
+  return WriteReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4);
+}
+
+/**
+ * @brief Check if gyroscope digital LPF1 is enabled
+ * @param[out] enable The returned gyroscope digital LPF1 enable state
+ * @retval Error code
+ */
+int8_t ISDS_isGyroDigitalLpf1Enabled(ISDS_state_t *enable)
+{
+  ISDS_ctrl4_t ctrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4))
+  {
+    return WE_FAIL;
+  }
+
+  *enable = (ISDS_state_t) ctrl4.enGyroLPF1;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Disable the I2C interface
+ * @param[in] i2cDisable I2C interface disable state (0: I2C enabled, 1: I2C disabled)
+ * @retval Error code
+ */
+int8_t ISDS_disableI2CInterface(ISDS_state_t i2cDisable)
+{
+  ISDS_ctrl4_t ctrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl4.i2cDisable = i2cDisable;
+
+  return WriteReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4);
+}
+
+/**
+ * @brief Read the I2C interface disable state [enabled, disabled]
+ * @param[out] i2cDisabled The returned I2C interface disable state (0: I2C enabled, 1: I2C disabled)
+ * @retval Error code
+ */
+int8_t ISDS_isI2CInterfaceDisabled(ISDS_state_t *i2cDisabled)
+{
+  ISDS_ctrl4_t ctrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4))
+  {
+    return WE_FAIL;
+  }
+
+  *i2cDisabled = (ISDS_state_t) ctrl4.i2cDisable;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable masking of the accelerometer and gyroscope data-ready signals
+ * until the settling of the sensor filters is completed
+ * @param[in] dataReadyMask Masking enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableDataReadyMask(ISDS_state_t dataReadyMask)
+{
+  ISDS_ctrl4_t ctrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl4.dataReadyMask = dataReadyMask;
+
+  return WriteReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4);
+}
+
+/**
+ * @brief Check if masking of the accelerometer and gyroscope data-ready signals
+ * until the settling of the sensor filters is completed is enabled
+ * @param[out] dataReadyMask The returned masking enable state
+ * @retval Error code
+ */
+int8_t ISDS_isDataReadyMaskEnabled(ISDS_state_t *dataReadyMask)
+{
+  ISDS_ctrl4_t ctrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4))
+  {
+    return WE_FAIL;
+  }
+
+  *dataReadyMask = (ISDS_state_t) ctrl4.dataReadyMask;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the data enable (DEN) data ready interrupt on INT_0
+ * @param[in] int0DataReady Data enable data (DEN) ready interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableDataEnableDataReadyINT0(ISDS_state_t int0DataReady)
+{
+  ISDS_ctrl4_t ctrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl4.dataEnableDataReadyOnInt0 = int0DataReady;
+
+  return WriteReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4);
+}
+
+/**
+ * @brief Check if the data enable (DEN) data ready interrupt on INT_0 is enabled
+ * @param[out] int0DataReady The returned data enable (DEN) data ready interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isDataEnableDataReadyINT0Enabled(ISDS_state_t *int0DataReady)
+{
+  ISDS_ctrl4_t ctrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4))
+  {
+    return WE_FAIL;
+  }
+
+  *int0DataReady = (ISDS_state_t) ctrl4.dataEnableDataReadyOnInt0;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable signal routing from INT_1 to INT_0
+ * @param[in] int1OnInt0 Signal routing INT_1 to INT_0 state
+ * @retval Error code
+ */
+int8_t ISDS_setInt1OnInt0(ISDS_state_t int1OnInt0)
+{
+  ISDS_ctrl4_t ctrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl4.int1OnInt0 = int1OnInt0;
+
+  return WriteReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4);
+}
+
+/**
+ * @brief Check if signal routing from INT_1 to INT_0 is enabled
+ * @param[out] int1OnInt0 The returned routing enable state.
+ * @retval Error code
+ */
+int8_t ISDS_getInt1OnInt0(ISDS_state_t *int1OnInt0)
+{
+  ISDS_ctrl4_t ctrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4))
+  {
+    return WE_FAIL;
+  }
+
+  *int1OnInt0 = (ISDS_state_t) ctrl4.int1OnInt0;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable gyroscope sleep mode
+ * @param[in] gyroSleepMode Gyroscope sleep mode enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableGyroSleepMode(ISDS_state_t gyroSleepMode)
+{
+  ISDS_ctrl4_t ctrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl4.enGyroSleepMode = gyroSleepMode;
+
+  return WriteReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4);
+}
+
+/**
+ * @brief Check if gyroscope sleep mode is enabled
+ * @param[out] gyroSleepMode The returned gyroscope sleep mode enable state
+ * @retval Error code
+ */
+int8_t ISDS_isGyroSleepModeEnabled(ISDS_state_t *gyroSleepMode)
+{
+  ISDS_ctrl4_t ctrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4))
+  {
+    return WE_FAIL;
+  }
+
+  *gyroSleepMode = (ISDS_state_t) ctrl4.enGyroSleepMode;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable extension of the data enable (DEN) functionality to accelerometer sensor
+ * @param[in] extendToAcc Extension of data enable (DEN) functionality enable state
+ * @retval Error code
+ */
+int8_t ISDS_extendDataEnableToAcc(ISDS_state_t extendToAcc)
+{
+  ISDS_ctrl4_t ctrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl4.dataEnableExtendToAcc = extendToAcc;
+
+  return WriteReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4);
+}
+
+/**
+ * @brief Check if extension of the data enable (DEN) functionality to accelerometer sensor is enabled
+ * @param[out] extendToAcc The returned extension of data enable (DEN) functionality enable state
+ * @retval Error code
+ */
+int8_t ISDS_isDataEnableExtendedToAcc(ISDS_state_t *extendToAcc)
+{
+  ISDS_ctrl4_t ctrl4;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_4_REG, 1, (uint8_t *) &ctrl4))
+  {
+    return WE_FAIL;
+  }
+
+  *extendToAcc = (ISDS_state_t) ctrl4.dataEnableExtendToAcc;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_CTRL_5_REG */
+
+/**
+ * @brief Set the accelerometer self test mode
+ * @param[in] selfTest Accelerometer self test mode
+ * @retval Error code
+ */
+int8_t ISDS_setAccSelfTestMode(ISDS_accSelfTestMode_t selfTest)
+{
+  ISDS_ctrl5_t ctrl5;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_5_REG, 1, (uint8_t *) &ctrl5))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl5.accSelfTest = selfTest;
+
+  return WriteReg(ISDS_CTRL_5_REG, 1, (uint8_t *) &ctrl5);
+}
+
+/**
+ * @brief Read the accelerometer self test mode
+ * @param[out] selfTest The returned accelerometer self test mode
+ * @retval Error code
+ */
+int8_t ISDS_getAccSelfTestMode(ISDS_accSelfTestMode_t *selfTest)
+{
+  ISDS_ctrl5_t ctrl5;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_5_REG, 1, (uint8_t *) &ctrl5))
+  {
+    return WE_FAIL;
+  }
+
+  *selfTest = (ISDS_accSelfTestMode_t) ctrl5.accSelfTest;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the gyroscope self test mode
+ * @param[in] selfTest Gyroscope self test mode
+ * @retval Error code
+ */
+int8_t ISDS_setGyroSelfTestMode(ISDS_gyroSelfTestMode_t selfTest)
+{
+  ISDS_ctrl5_t ctrl5;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_5_REG, 1, (uint8_t *) &ctrl5))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl5.gyroSelfTest = selfTest;
+
+  return WriteReg(ISDS_CTRL_5_REG, 1, (uint8_t *) &ctrl5);
+}
+
+/**
+ * @brief Read the gyroscope self test mode
+ * @param[out] selfTest The returned gyroscope self test mode
+ * @retval Error code
+ */
+int8_t ISDS_getGyroSelfTestMode(ISDS_gyroSelfTestMode_t *selfTest)
+{
+  ISDS_ctrl5_t ctrl5;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_5_REG, 1, (uint8_t *) &ctrl5))
+  {
+    return WE_FAIL;
+  }
+
+  *selfTest = (ISDS_gyroSelfTestMode_t) ctrl5.gyroSelfTest;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the data enable (DEN) active level
+ * @param[in] activeHigh Data enable (DEN) active level (0: active low, 1: active high)
+ * @retval Error code
+ */
+int8_t ISDS_setDataEnableActiveHigh(ISDS_state_t activeHigh)
+{
+  ISDS_ctrl5_t ctrl5;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_5_REG, 1, (uint8_t *) &ctrl5))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl5.dataEnableActiveLevel = activeHigh;
+
+  return WriteReg(ISDS_CTRL_5_REG, 1, (uint8_t *) &ctrl5);
+}
+
+/**
+ * @brief Get the data enable (DEN) active level
+ * @param[out] activeHigh The returned data enable (DEN) active level (0: active low, 1: active high)
+ * @retval Error code
+ */
+int8_t ISDS_isDataEnableActiveHigh(ISDS_state_t *activeHigh)
+{
+  ISDS_ctrl5_t ctrl5;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_5_REG, 1, (uint8_t *) &ctrl5))
+  {
+    return WE_FAIL;
+  }
+
+  *activeHigh = (ISDS_state_t) ctrl5.dataEnableActiveLevel;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the circular burst-mode (rounding) pattern
+ * @param[in] roundingPattern Rounding pattern
+ * @retval Error code
+ */
+int8_t ISDS_setRoundingPattern(ISDS_roundingPattern_t roundingPattern)
+{
+  ISDS_ctrl5_t ctrl5;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_5_REG, 1, (uint8_t *) &ctrl5))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl5.rounding = roundingPattern;
+
+  return WriteReg(ISDS_CTRL_5_REG, 1, (uint8_t *) &ctrl5);
+}
+
+/**
+ * @brief Read the circular burst-mode (rounding) pattern
+ * @param[out] roundingPattern The returned rounding pattern
+ * @retval Error code
+ */
+int8_t ISDS_getRoundingPattern(ISDS_roundingPattern_t *roundingPattern)
+{
+  ISDS_ctrl5_t ctrl5;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_5_REG, 1, (uint8_t *) &ctrl5))
+  {
+    return WE_FAIL;
+  }
+
+  *roundingPattern = (ISDS_roundingPattern_t) ctrl5.rounding;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_CTRL_6_REG */
+
+/**
+ * @brief Set the gyroscope low-pass filter (LPF1) bandwidth
+ * @param[in] bandwidth Low-pass filter bandwidth
+ * @retval Error code
+ */
+int8_t ISDS_setGyroLowPassFilterBandwidth(ISDS_gyroLPF_t bandwidth)
+{
+  ISDS_ctrl6_t ctrl6;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_6_REG, 1, (uint8_t *) &ctrl6))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl6.gyroLowPassFilterType = bandwidth;
+
+  return WriteReg(ISDS_CTRL_6_REG, 1, (uint8_t *) &ctrl6);
+}
+
+/**
+ * @brief Read the gyroscope low-pass filter (LPF1) bandwidth
+ * @param[out] bandwidth The returned low-pass filter bandwidth
+ * @retval Error code
+ */
+int8_t ISDS_getGyroLowPassFilterBandwidth(ISDS_gyroLPF_t *bandwidth)
+{
+  ISDS_ctrl6_t ctrl6;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_6_REG, 1, (uint8_t *) &ctrl6))
+  {
+    return WE_FAIL;
+  }
+
+  *bandwidth = (ISDS_gyroLPF_t) ctrl6.gyroLowPassFilterType;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the weight of the user offset words
+ * @param[in] offsetWeight Offset weight
+ * @retval Error code
+ */
+int8_t ISDS_setOffsetWeight(ISDS_state_t offsetWeight)
+{
+  ISDS_ctrl6_t ctrl6;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_6_REG, 1, (uint8_t *) &ctrl6))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl6.userOffsetsWeight = offsetWeight;
+
+  return WriteReg(ISDS_CTRL_6_REG, 1, (uint8_t *) &ctrl6);
+}
+
+/**
+ * @brief Read the weight of the user offset words
+ * @param[out] offsetWeight The returned offset weight
+ * @retval Error code
+ */
+int8_t ISDS_getOffsetWeight(ISDS_state_t *offsetWeight)
+{
+  ISDS_ctrl6_t ctrl6;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_6_REG, 1, (uint8_t *) &ctrl6))
+  {
+    return WE_FAIL;
+  }
+
+  *offsetWeight = (ISDS_state_t) ctrl6.userOffsetsWeight;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Disable the accelerometer high performance mode
+ * @param[in] disable Accelerometer high performance mode disable state
+ * @retval Error code
+ */
+int8_t ISDS_disableAccHighPerformanceMode(ISDS_state_t disable)
+{
+  ISDS_ctrl6_t ctrl6;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_6_REG, 1, (uint8_t *) &ctrl6))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl6.accHighPerformanceModeDisable = disable;
+
+  return WriteReg(ISDS_CTRL_6_REG, 1, (uint8_t *) &ctrl6);
+}
+
+/**
+ * @brief Check if the accelerometer high performance mode is disabled
+ * @param[out] disable The returned accelerometer high performance mode disable state
+ * @retval Error code
+ */
+int8_t ISDS_isAccHighPerformanceModeDisabled(ISDS_state_t *disable)
+{
+  ISDS_ctrl6_t ctrl6;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_6_REG, 1, (uint8_t *) &ctrl6))
+  {
+    return WE_FAIL;
+  }
+
+  *disable = (ISDS_state_t) ctrl6.accHighPerformanceModeDisable;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the data enable (DEN) trigger mode
+ * @param[in] triggerMode Data enable (DEN) trigger mode
+ * @retval Error code
+ */
+int8_t ISDS_setDataEnableTriggerMode(ISDS_dataEnableTriggerMode_t triggerMode)
+{
+  ISDS_ctrl6_t ctrl6;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_6_REG, 1, (uint8_t *) &ctrl6))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl6.dataEnableTriggerMode = triggerMode;
+
+  return WriteReg(ISDS_CTRL_6_REG, 1, (uint8_t *) &ctrl6);
+}
+
+/**
+ * @brief Read the data enable (DEN) trigger mode
+ * @param[out] triggerMode The returned data enable (DEN) trigger mode
+ * @retval Error code
+ */
+int8_t ISDS_getDataEnableTriggerMode(ISDS_dataEnableTriggerMode_t *triggerMode)
+{
+  ISDS_ctrl6_t ctrl6;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_6_REG, 1, (uint8_t *) &ctrl6))
+  {
+    return WE_FAIL;
+  }
+
+  *triggerMode = (ISDS_dataEnableTriggerMode_t) ctrl6.dataEnableTriggerMode;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_CTRL_7_REG */
+
+/**
+ * @brief Enable/disable the source register rounding function
+ * @param[in] rounding Rounding enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableRounding(ISDS_state_t rounding)
+{
+  ISDS_ctrl7_t ctrl7;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_7_REG, 1, (uint8_t *) &ctrl7))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl7.enRounding = rounding;
+
+  return WriteReg(ISDS_CTRL_7_REG, 1, (uint8_t *) &ctrl7);
+}
+
+/**
+ * @brief Check if the source register rounding function is enabled
+ * @param[out] rounding The returned rounding enable state
+ * @retval Error code
+ */
+int8_t ISDS_isRoundingEnabled(ISDS_state_t *rounding)
+{
+  ISDS_ctrl7_t ctrl7;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_7_REG, 1, (uint8_t *) &ctrl7))
+  {
+    return WE_FAIL;
+  }
+
+  *rounding = (ISDS_state_t) ctrl7.enRounding;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the gyroscope digital high pass filter cutoff
+ * @param[in] cutoff Gyroscope digital high pass filter cutoff
+ * @retval Error code
+ */
+int8_t ISDS_setGyroDigitalHighPassCutoff(ISDS_gyroDigitalHighPassCutoff_t cutoff)
+{
+  ISDS_ctrl7_t ctrl7;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_7_REG, 1, (uint8_t *) &ctrl7))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl7.gyroDigitalHighPassCutoff = cutoff;
+
+  return WriteReg(ISDS_CTRL_7_REG, 1, (uint8_t *) &ctrl7);
+}
+
+/**
+ * @brief Read the gyroscope digital high pass filter cutoff
+ * @param[out] cutoff The returned gyroscope digital high pass filter cutoff
+ * @retval Error code
+ */
+int8_t ISDS_getGyroDigitalHighPassCutoff(ISDS_gyroDigitalHighPassCutoff_t *cutoff)
+{
+  ISDS_ctrl7_t ctrl7;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_7_REG, 1, (uint8_t *) &ctrl7))
+  {
+    return WE_FAIL;
+  }
+
+  *cutoff = (ISDS_gyroDigitalHighPassCutoff_t) ctrl7.gyroDigitalHighPassCutoff;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable the gyroscope digital high pass filter
+ * @param[in] highPass Gyroscope digital high pass filter enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableGyroDigitalHighPass(ISDS_state_t highPass)
+{
+  ISDS_ctrl7_t ctrl7;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_7_REG, 1, (uint8_t *) &ctrl7))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl7.gyroDigitalHighPassEnable = highPass;
+
+  return WriteReg(ISDS_CTRL_7_REG, 1, (uint8_t *) &ctrl7);
+}
+
+/**
+ * @brief Check if the gyroscope digital high pass filter is enabled
+ * @param[out] highPass The returned gyroscope digital high pass filter enable state
+ * @retval Error code
+ */
+int8_t ISDS_isGyroDigitalHighPassEnabled(ISDS_state_t *highPass)
+{
+  ISDS_ctrl7_t ctrl7;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_7_REG, 1, (uint8_t *) &ctrl7))
+  {
+    return WE_FAIL;
+  }
+
+  *highPass = (ISDS_state_t) ctrl7.gyroDigitalHighPassEnable;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Disable the gyroscope high performance mode
+ * @param[in] disable Gyroscope high performance mode disable state
+ * @retval Error code
+ */
+int8_t ISDS_disableGyroHighPerformanceMode(ISDS_state_t disable)
+{
+  ISDS_ctrl7_t ctrl7;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_7_REG, 1, (uint8_t *) &ctrl7))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl7.gyroHighPerformanceModeDisable = disable;
+
+  return WriteReg(ISDS_CTRL_7_REG, 1, (uint8_t *) &ctrl7);
+}
+
+/**
+ * @brief Check if the gyroscope high performance mode is disabled
+ * @param[out] disable The returned gyroscope high performance mode disable state
+ * @retval Error code
+ */
+int8_t ISDS_isGyroHighPerformanceModeDisabled(ISDS_state_t *disable)
+{
+  ISDS_ctrl7_t ctrl7;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_7_REG, 1, (uint8_t *) &ctrl7))
+  {
+    return WE_FAIL;
+  }
+
+  *disable = (ISDS_state_t) ctrl7.gyroHighPerformanceModeDisable;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_CTRL_8_REG */
+
+/**
+ * @brief Enable/disable the low pass filter for 6D orientation detection
+ * @param[in] lowPass Low pass filter enable state
+ * @retval Error code
+ */
+int8_t ISDS_enable6dLowPass(ISDS_state_t lowPass)
+{
+  ISDS_ctrl8_t ctrl8;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl8.en6dLowPass = lowPass;
+
+  return WriteReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8);
+}
+
+/**
+ * @brief Check if the low pass filter for 6D orientation detection is enabled
+ * @param[out] lowPass The returned low pass filter enable state
+ * @retval Error code
+ */
+int8_t ISDS_is6dLowPassEnabled(ISDS_state_t *lowPass)
+{
+  ISDS_ctrl8_t ctrl8;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8))
+  {
+    return WE_FAIL;
+  }
+
+  *lowPass = (ISDS_state_t) ctrl8.en6dLowPass;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the accelerometer high pass / slope filter
+ * (i.e. the high-pass path of the composite filter block).
+ * @param[in] filterEnable HP / slope filter enable state (0: select low-pass path; 1: select high-pass path)
+ * @retval Error code
+ */
+int8_t ISDS_enableAccHighPassSlopeFilter(ISDS_state_t filterEnable)
+{
+  ISDS_ctrl8_t ctrl8;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl8.enAccHighPassSlopeFilter = filterEnable;
+
+  return WriteReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8);
+}
+
+/**
+ * @brief Check if the accelerometer slope filter / high pass filter is enabled
+ * @param[out] filterEnable The returned filter enable state
+ * @retval Error code
+ */
+int8_t ISDS_isAccHighPassSlopeFilterEnabled(ISDS_state_t *filterEnable)
+{
+  ISDS_ctrl8_t ctrl8;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8))
+  {
+    return WE_FAIL;
+  }
+
+  *filterEnable = (ISDS_state_t) ctrl8.enAccHighPassSlopeFilter;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set composite filter input
+ * @param[in] inputCompositeFilter Composite filter input
+ * @retval Error code
+ */
+int8_t ISDS_setInputCompositeFilter(ISDS_inputCompositeFilter_t inputCompositeFilter)
+{
+  ISDS_ctrl8_t ctrl8;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl8.inputComposite = inputCompositeFilter;
+
+  return WriteReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8);
+}
+
+/**
+ * @brief Read composite filter input
+ * @param[out] inputCompositeFilter The returned composite filter input
+ * @retval Error code
+ */
+int8_t ISDS_getInputCompositeFilter(ISDS_inputCompositeFilter_t *inputCompositeFilter)
+{
+  ISDS_ctrl8_t ctrl8;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8))
+  {
+    return WE_FAIL;
+  }
+
+  *inputCompositeFilter = (ISDS_inputCompositeFilter_t) ctrl8.inputComposite;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable high pass filter reference mode
+ *
+ * Note that for reference mode to be enabled, it is also required to call
+ * ISDS_enableAccHighPassSlopeFilter(ISDS_enable) and call
+ * ISDS_setAccFilterConfig() with a non-zero argument.
+ *
+ * The first accelerometer output sample after enabling reference mode has to be discarded.
+ *
+ * @param[in] refMode High pass filter reference mode enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableHighPassFilterRefMode(ISDS_state_t refMode)
+{
+  ISDS_ctrl8_t ctrl8;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl8.highPassFilterRefMode = refMode;
+
+  return WriteReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8);
+}
+
+/**
+ * @brief Check if the high pass filter reference mode is enabled
+ * @param[out] refMode The returned high pass filter reference mode enable state
+ * @retval Error code
+ */
+int8_t ISDS_isHighPassFilterRefModeEnabled(ISDS_state_t *refMode)
+{
+  ISDS_ctrl8_t ctrl8;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8))
+  {
+    return WE_FAIL;
+  }
+
+  *refMode = (ISDS_state_t) ctrl8.highPassFilterRefMode;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set accelerometer LPF2 and high pass filter configuration and cutoff setting
+ * @param[in] filterConfig Filter configuration
+ * @retval Error code
+ */
+int8_t ISDS_setAccFilterConfig(ISDS_accFilterConfig_t filterConfig)
+{
+  ISDS_ctrl8_t ctrl8;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl8.accFilterConfig = filterConfig;
+
+  return WriteReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8);
+}
+
+/**
+ * @brief Read the accelerometer LPF2 and high pass filter configuration and cutoff setting
+ * @param[out] filterConfig The returned filter configuration
+ * @retval Error code
+ */
+int8_t ISDS_getAccFilterConfig(ISDS_accFilterConfig_t *filterConfig)
+{
+  ISDS_ctrl8_t ctrl8;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8))
+  {
+    return WE_FAIL;
+  }
+
+  *filterConfig = (ISDS_accFilterConfig_t) ctrl8.accFilterConfig;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the accelerometer low pass filter (LPF2)
+ * @param[in] lowPass Filter enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableAccLowPass(ISDS_state_t lowPass)
+{
+  ISDS_ctrl8_t ctrl8;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl8.enAccLowPass = lowPass;
+
+  return WriteReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8);
+}
+
+/**
+ * @brief Check if the accelerometer low pass filter (LPF2) is enabled
+ * @param[out] lowPass The returned filter enable state
+ * @retval Error code
+ */
+int8_t ISDS_isAccLowPassEnabled(ISDS_state_t *lowPass)
+{
+  ISDS_ctrl8_t ctrl8;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_8_REG, 1, (uint8_t *) &ctrl8))
+  {
+    return WE_FAIL;
+  }
+
+  *lowPass = (ISDS_state_t) ctrl8.enAccLowPass;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_CTRL_9_REG */
+
+/**
+ * @brief Set the data enable (DEN) stamping sensor
+ * @param[in] sensor Data enable (DEN) stamping sensor
+ * @retval Error code
+ */
+int8_t ISDS_setDataEnableStampingSensor(ISDS_dataEnableStampingSensor_t sensor)
+{
+  ISDS_ctrl9_t ctrl9;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_9_REG, 1, (uint8_t *) &ctrl9))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl9.dataEnableStampingSensor = sensor;
+
+  return WriteReg(ISDS_CTRL_9_REG, 1, (uint8_t *) &ctrl9);
+}
+
+/**
+ * @brief Get the data enable (DEN) stamping sensor
+ * @param[out] sensor The returned data enable (DEN) stamping sensor
+ * @retval Error code
+ */
+int8_t ISDS_getDataEnableStampingSensor(ISDS_dataEnableStampingSensor_t *sensor)
+{
+  ISDS_ctrl9_t ctrl9;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_9_REG, 1, (uint8_t *) &ctrl9))
+  {
+    return WE_FAIL;
+  }
+
+  *sensor = (ISDS_dataEnableStampingSensor_t) ctrl9.dataEnableStampingSensor;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable storage of data enable (DEN) value in LSB of Z-axis
+ * @param[in] enable Storage of DEN value in LSB of Z-axis enable state
+ * @retval Error code
+ */
+int8_t ISDS_storeDataEnableValueInZAxisLSB(ISDS_state_t enable)
+{
+  ISDS_ctrl9_t ctrl9;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_9_REG, 1, (uint8_t *) &ctrl9))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl9.dataEnableValueZ = enable;
+
+  return WriteReg(ISDS_CTRL_9_REG, 1, (uint8_t *) &ctrl9);
+}
+
+/**
+ * @brief Check if storage of data enable (DEN) value in LSB of Z-axis is enabled
+ * @param[out] enable The returned storage of DEN value in LSB of Z-axis enable state
+ * @retval Error code
+ */
+int8_t ISDS_isStoreDataEnableValueInZAxisLSB(ISDS_state_t *enable)
+{
+  ISDS_ctrl9_t ctrl9;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_9_REG, 1, (uint8_t *) &ctrl9))
+  {
+    return WE_FAIL;
+  }
+
+  *enable = (ISDS_state_t) ctrl9.dataEnableValueZ;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable storage of data enable (DEN) value in LSB of Y-axis
+ * @param[in] enable Storage of DEN value in LSB of Y-axis enable state
+ * @retval Error code
+ */
+int8_t ISDS_storeDataEnableValueInYAxisLSB(ISDS_state_t enable)
+{
+  ISDS_ctrl9_t ctrl9;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_9_REG, 1, (uint8_t *) &ctrl9))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl9.dataEnableValueY = enable;
+
+  return WriteReg(ISDS_CTRL_9_REG, 1, (uint8_t *) &ctrl9);
+}
+
+/**
+ * @brief Check if storage of data enable (DEN) value in LSB of Y-axis is enabled
+ * @param[out] enable The returned storage of DEN value in LSB of Y-axis enable state
+ * @retval Error code
+ */
+int8_t ISDS_isStoreDataEnableValueInYAxisLSB(ISDS_state_t *enable)
+{
+  ISDS_ctrl9_t ctrl9;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_9_REG, 1, (uint8_t *) &ctrl9))
+  {
+    return WE_FAIL;
+  }
+
+  *enable = (ISDS_state_t) ctrl9.dataEnableValueY;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable storage of data enable (DEN) value in LSB of X-axis
+ * @param[in] enable Storage of DEN value in LSB of X-axis enable state
+ * @retval Error code
+ */
+int8_t ISDS_storeDataEnableValueInXAxisLSB(ISDS_state_t enable)
+{
+  ISDS_ctrl9_t ctrl9;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_9_REG, 1, (uint8_t *) &ctrl9))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl9.dataEnableValueX = enable;
+
+  return WriteReg(ISDS_CTRL_9_REG, 1, (uint8_t *) &ctrl9);
+}
+
+/**
+ * @brief Check if storage of data enable (DEN) value in LSB of X-axis is enabled
+ * @param[out] enable The returned storage of DEN value in LSB of X-axis enable state
+ * @retval Error code
+ */
+int8_t ISDS_isStoreDataEnableValueInXAxisLSB(ISDS_state_t *enable)
+{
+  ISDS_ctrl9_t ctrl9;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_9_REG, 1, (uint8_t *) &ctrl9))
+  {
+    return WE_FAIL;
+  }
+
+  *enable = (ISDS_state_t) ctrl9.dataEnableValueX;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_CTRL_10_REG */
+
+/**
+ * @brief Enable/disable embedded functionalities (tilt)
+ * @param[in] embeddedFuncEnable Embedded functionalities enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableEmbeddedFunctionalities(ISDS_state_t embeddedFuncEnable)
+{
+  ISDS_ctrl10_t ctrl10;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_10_REG, 1, (uint8_t *) &ctrl10))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl10.enEmbeddedFunc = embeddedFuncEnable;
+
+  return WriteReg(ISDS_CTRL_10_REG, 1, (uint8_t *) &ctrl10);
+}
+
+/**
+ * @brief Check if embedded functionalities (tilt) are enabled
+ * @param[out] embeddedFuncEnable The returned embedded functionalities enable state
+ * @retval Error code
+ */
+int8_t ISDS_areEmbeddedFunctionalitiesEnabled(ISDS_state_t *embeddedFuncEnable)
+{
+  ISDS_ctrl10_t ctrl10;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_10_REG, 1, (uint8_t *) &ctrl10))
+  {
+    return WE_FAIL;
+  }
+
+  *embeddedFuncEnable = (ISDS_state_t) ctrl10.enEmbeddedFunc;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable tilt calculation
+ * @param[in] tiltCalc Tilt calculation enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableTiltCalculation(ISDS_state_t tiltCalc)
+{
+  ISDS_ctrl10_t ctrl10;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_10_REG, 1, (uint8_t *) &ctrl10))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl10.enTiltCalculation = tiltCalc;
+
+  return WriteReg(ISDS_CTRL_10_REG, 1, (uint8_t *) &ctrl10);
+}
+
+/**
+ * @brief Check if tilt calculation is enabled
+ * @param[out] tiltCalc The returned tilt calculation enable state
+ * @retval Error code
+ */
+int8_t ISDS_isTiltCalculationEnabled(ISDS_state_t *tiltCalc)
+{
+  ISDS_ctrl10_t ctrl10;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_10_REG, 1, (uint8_t *) &ctrl10))
+  {
+    return WE_FAIL;
+  }
+
+  *tiltCalc = (ISDS_state_t) ctrl10.enTiltCalculation;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable timestamp count
+ * @param[in] timestampCount Timestamp count enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableTimestampCount(ISDS_state_t timestampCount)
+{
+  ISDS_ctrl10_t ctrl10;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_10_REG, 1, (uint8_t *) &ctrl10))
+  {
+    return WE_FAIL;
+  }
+
+  ctrl10.enTimestampCount = timestampCount;
+
+  return WriteReg(ISDS_CTRL_10_REG, 1, (uint8_t *) &ctrl10);
+}
+
+/**
+ * @brief Check if timestamp count is enabled
+ * @param[out] timestampCount The returned timestamp count enable state
+ * @retval Error code
+ */
+int8_t ISDS_isTimestampCountEnabled(ISDS_state_t *timestampCount)
+{
+  ISDS_ctrl10_t ctrl10;
+
+  if (WE_FAIL == ReadReg(ISDS_CTRL_10_REG, 1, (uint8_t *) &ctrl10))
+  {
+    return WE_FAIL;
+  }
+
+  *timestampCount = (ISDS_state_t) ctrl10.enTimestampCount;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_WAKE_UP_EVENT_REG */
+
+/**
+ * @brief Read the overall wake-up event status
+ * @param[out] status The returned wake-up event status
+ * @retval Error code
+ */
+int8_t ISDS_getWakeUpEventRegister(ISDS_wakeUpEvent_t *status)
+{
+  return ReadReg(ISDS_WAKE_UP_EVENT_REG, 1, (uint8_t *) status);
+}
+
+/**
+ * @brief Read the wake-up event detection status on axis X
+ * @param[out] wakeUpX The returned wake-up event detection status on axis X
+ * @retval Error code
+ */
+int8_t ISDS_isWakeUpXEvent(ISDS_state_t *wakeUpX)
+{
+  ISDS_wakeUpEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *wakeUpX = (ISDS_state_t) status.wakeUpX;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the wake-up event detection status on axis Y
+ * @param[out] wakeUpY The returned wake-up event detection status on axis Y
+ * @retval Error code
+ */
+int8_t ISDS_isWakeUpYEvent(ISDS_state_t *wakeUpY)
+{
+  ISDS_wakeUpEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *wakeUpY = (ISDS_state_t) status.wakeUpY;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the wake-up event detection status on axis Z
+ * @param[out] wakeUpZ The returned wake-up event detection status on axis Z
+ * @retval Error code
+ */
+int8_t ISDS_isWakeUpZEvent(ISDS_state_t *wakeUpZ)
+{
+  ISDS_wakeUpEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *wakeUpZ = (ISDS_state_t) status.wakeUpZ;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the wake-up event detection status (wake-up event on any axis)
+ * @param[out] wakeUpState The returned wake-up event detection state
+ * @retval Error code
+ */
+int8_t ISDS_isWakeUpEvent(ISDS_state_t *wakeUpState)
+{
+  ISDS_wakeUpEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *wakeUpState = (ISDS_state_t) status.wakeUpState;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the sleep state [not sleeping/sleeping]
+ * @param[out] sleepState The returned sleep state.
+ * @retval Error code
+ */
+int8_t ISDS_getSleepState(ISDS_state_t *sleepState)
+{
+  ISDS_wakeUpEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *sleepState = (ISDS_state_t) status.sleepState;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the free-fall event detection status
+ * @param[out] freeFall The returned free-fall event detection state
+ * @retval Error code
+ */
+int8_t ISDS_isFreeFallEvent(ISDS_state_t *freeFall)
+{
+  ISDS_wakeUpEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *freeFall = (ISDS_state_t) status.freeFallState;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_TAP_EVENT_REG */
+
+/**
+ * @brief Read the overall tap event status
+ * @param[out] status The returned tap event status
+ * @retval Error code
+ */
+int8_t ISDS_getTapEventRegister(ISDS_tapEvent_t *status)
+{
+  return ReadReg(ISDS_TAP_EVENT_REG, 1, (uint8_t *) status);
+}
+
+/**
+ * @brief Read the tap event status (tap event on any axis)
+ * @param[out] tapEventState The returned tap event state
+ * @retval Error code
+ */
+int8_t ISDS_isTapEvent(ISDS_state_t *tapEventState)
+{
+  ISDS_tapEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *tapEventState = (ISDS_state_t) status.tapEventState;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the tap event status on axis X
+ * @param[out] tapXAxis The returned tap event status on axis X
+ * @retval Error code
+ */
+int8_t ISDS_isTapEventXAxis(ISDS_state_t *tapXAxis)
+{
+  ISDS_tapEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *tapXAxis = (ISDS_state_t) status.tapXAxis;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the tap event status on axis Y
+ * @param[out] tapYAxis The returned tap event status on axis Y
+ * @retval Error code
+ */
+int8_t ISDS_isTapEventYAxis(ISDS_state_t *tapYAxis)
+{
+  ISDS_tapEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *tapYAxis = (ISDS_state_t) status.tapYAxis;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the tap event status on axis Z
+ * @param[out] tapZAxis The returned tap event status on axis Z
+ * @retval Error code
+ */
+int8_t ISDS_isTapEventZAxis(ISDS_state_t *tapZAxis)
+{
+  ISDS_tapEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *tapZAxis = (ISDS_state_t) status.tapZAxis;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the double-tap event status
+ * @param[out] doubleTap The returned double-tap event status
+ * @retval Error code
+ */
+int8_t ISDS_isDoubleTapEvent(ISDS_state_t *doubleTap)
+{
+  ISDS_tapEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *doubleTap = (ISDS_state_t) status.doubleState;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the single-tap event status
+ * @param[out] singleTap The returned single-tap event status
+ * @retval Error code
+ */
+int8_t ISDS_isSingleTapEvent(ISDS_state_t *singleTap)
+{
+  ISDS_tapEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *singleTap = (ISDS_state_t) status.singleState;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the tap event acceleration sign (direction of tap event)
+ * @param[out] tapSign The returned tap event acceleration sign
+ * @retval Error code
+ */
+int8_t ISDS_getTapSign(ISDS_tapSign_t *tapSign)
+{
+  ISDS_tapEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *tapSign = (ISDS_tapSign_t) status.tapSign;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_6D_EVENT_REG */
+
+/**
+ * @brief Read register containing info on 6D orientation change event
+ * @param[out] status The returned 6D event status
+ * @retval Error code
+ */
+int8_t ISDS_get6dEventRegister(ISDS_6dEvent_t *status)
+{
+  return ReadReg(ISDS_6D_EVENT_REG, 1, (uint8_t *) status);
+}
+
+/**
+ * @brief Check if 6D orientation change event has occurred
+ * @param[out] orientationChanged The returned 6D orientation change event status
+ * @retval Error code
+ */
+int8_t ISDS_has6dOrientationChanged(ISDS_state_t *orientationChanged)
+{
+  ISDS_6dEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_6D_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *orientationChanged = (ISDS_state_t) status.sixDChange;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the XL over threshold state (6D orientation)
+ * @param[out] xlOverThreshold The returned XL over threshold state
+ * @retval Error code
+ */
+int8_t ISDS_isXLOverThreshold(ISDS_state_t *xlOverThreshold)
+{
+  ISDS_6dEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_6D_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *xlOverThreshold = (ISDS_state_t) status.xlOverThreshold;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the XH over threshold state (6D orientation)
+ * @param[out] xhOverThreshold The returned XH over threshold state
+ * @retval Error code
+ */
+int8_t ISDS_isXHOverThreshold(ISDS_state_t *xhOverThreshold)
+{
+  ISDS_6dEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_6D_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *xhOverThreshold = (ISDS_state_t) status.xhOverThreshold;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the YL over threshold state (6D orientation)
+ * @param[out] ylOverThreshold The returned YL over threshold state
+ * @retval Error code
+ */
+int8_t ISDS_isYLOverThreshold(ISDS_state_t *ylOverThreshold)
+{
+  ISDS_6dEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_6D_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *ylOverThreshold = (ISDS_state_t) status.ylOverThreshold;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the YH over threshold state (6D orientation)
+ * @param[out] yhOverThreshold The returned YH over threshold state
+ * @retval Error code
+ */
+int8_t ISDS_isYHOverThreshold(ISDS_state_t *yhOverThreshold)
+{
+  ISDS_6dEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_6D_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *yhOverThreshold = (ISDS_state_t) status.yhOverThreshold;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the ZL over threshold state (6D orientation)
+ * @param[out] zlOverThreshold The returned ZL over threshold state
+ * @retval Error code
+ */
+int8_t ISDS_isZLOverThreshold(ISDS_state_t *zlOverThreshold)
+{
+  ISDS_6dEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_6D_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *zlOverThreshold = (ISDS_state_t) status.zlOverThreshold;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the ZH over threshold state (6D orientation)
+ * @param[out] zhOverThreshold The returned ZH over threshold state
+ * @retval Error code
+ */
+int8_t ISDS_isZHOverThreshold(ISDS_state_t *zhOverThreshold)
+{
+  ISDS_6dEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_6D_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *zhOverThreshold = (ISDS_state_t) status.zhOverThreshold;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the data enable (DEN) data ready signal.
+ * It is set high when data output is related to the data coming from a DEN active condition.
+ * @param[out] dataReady The returned DEN data ready signal state
+ * @retval Error code
+ */
+int8_t ISDS_isDataEnableDataReady(ISDS_state_t *dataReady)
+{
+  ISDS_6dEvent_t status;
+
+  if (WE_FAIL == ReadReg(ISDS_6D_EVENT_REG, 1, (uint8_t *) &status))
+  {
+    return WE_FAIL;
+  }
+
+  *dataReady = (ISDS_state_t) status.dataEnableDataReady;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_STATUS_REG */
+
+/**
+ * @brief Get overall sensor status
+ * @param[out] status The returned sensor event data
+ * @retval Error code
+ */
+int8_t ISDS_getStatusRegister(ISDS_status_t *status)
+{
+  return ReadReg(ISDS_STATUS_REG, 1, (uint8_t *) status);
+}
+
+/**
+ * @brief Check if new acceleration samples are available
+ * @param[out] dataReady The returned data-ready state
+ * @retval Error code
+ */
+int8_t ISDS_isAccelerationDataReady(ISDS_state_t *dataReady)
+{
+  ISDS_status_t statusRegister;
+
+  if (WE_FAIL == ReadReg(ISDS_STATUS_REG, 1, (uint8_t *) &statusRegister))
+  {
+    return WE_FAIL;
+  }
+
+  *dataReady = (ISDS_state_t) statusRegister.accDataReady;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Check if new gyroscope samples are available
+ * @param[out] dataReady The returned data-ready state
+ * @retval Error code
+ */
+int8_t ISDS_isGyroscopeDataReady(ISDS_state_t *dataReady)
+{
+  ISDS_status_t statusRegister;
+
+  if (WE_FAIL == ReadReg(ISDS_STATUS_REG, 1, (uint8_t *) &statusRegister))
+  {
+    return WE_FAIL;
+  }
+
+  *dataReady = (ISDS_state_t) statusRegister.gyroDataReady;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Check if new temperature samples are available
+ * @param[out] dataReady The returned data-ready state
+ * @retval Error code
+ */
+int8_t ISDS_isTemperatureDataReady(ISDS_state_t *dataReady)
+{
+  ISDS_status_t statusRegister;
+
+  if (WE_FAIL == ReadReg(ISDS_STATUS_REG, 1, (uint8_t *) &statusRegister))
+  {
+    return WE_FAIL;
+  }
+
+  *dataReady = (ISDS_state_t) statusRegister.tempDataReady;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_FIFO_STATUS_1_REG */
+/* ISDS_FIFO_STATUS_2_REG */
+/* ISDS_FIFO_STATUS_3_REG */
+/* ISDS_FIFO_STATUS_4_REG */
+
+/**
+ * @brief Get overall FIFO status
+ *
+ * This is a convenience function querying all FIFO status registers in one read operation.
+ *
+ * @param[out] status The returned FIFO status flags register
+ * @param[out] fillLevel The returned FIFO fill level (0-2047)
+ * @param[out] fifoPattern Word of recursive pattern read at the next read
+ * @retval Error code
+ */
+int8_t ISDS_getFifoStatus(ISDS_fifoStatus2_t *status, uint16_t *fillLevel, uint16_t *fifoPattern)
+{
+  uint8_t tmp[4];
+  if (WE_FAIL == ReadReg(ISDS_FIFO_STATUS_1_REG, 4, tmp))
+  {
+    return WE_FAIL;
+  }
+
+  ISDS_fifoStatus1_t *fifoStatus1 = (ISDS_fifoStatus1_t *) tmp;
+  ISDS_fifoStatus2_t *fifoStatus2 = (ISDS_fifoStatus2_t *) tmp + 1;
+  ISDS_fifoStatus3_t *fifoStatus3 = (ISDS_fifoStatus3_t *) tmp + 2;
+  ISDS_fifoStatus4_t *fifoStatus4 = (ISDS_fifoStatus4_t *) tmp + 3;
+
+  *status = *(ISDS_fifoStatus2_t*) fifoStatus2;
+
+  *fillLevel = ((uint16_t) fifoStatus1->fifoFillLevelLsb) |
+               (((uint16_t) (fifoStatus2->fifoFillLevelMsb & 0x07)) << 8);
+
+  *fifoPattern = ((uint16_t) fifoStatus3->fifoPatternLsb) |
+                 (((uint16_t) (fifoStatus4->fifoPatternMsb & 0x03)) << 8);
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Get FIFO status flags register
+ * @param[out] status The returned FIFO status flags register
+ * @retval Error code
+ */
+int8_t ISDS_getFifoStatus2Register(ISDS_fifoStatus2_t *status)
+{
+  return ReadReg(ISDS_FIFO_STATUS_2_REG, 1, (uint8_t *) status);
+}
+
+/**
+ * @brief Read the FIFO fill level
+ * @param[out] fillLevel The returned FIFO fill level (0-2047)
+ * @retval Error code
+ */
+int8_t ISDS_getFifoFillLevel(uint16_t *fillLevel)
+{
+  uint8_t tmp[2];
+  if (WE_FAIL == ReadReg(ISDS_FIFO_STATUS_1_REG, 2, tmp))
+  {
+    return WE_FAIL;
+  }
+
+  ISDS_fifoStatus1_t *fifoStatus1 = (ISDS_fifoStatus1_t *) tmp;
+  ISDS_fifoStatus2_t *fifoStatus2 = (ISDS_fifoStatus2_t *) tmp + 1;
+
+  *fillLevel = ((uint16_t) fifoStatus1->fifoFillLevelLsb) |
+               (((uint16_t) (fifoStatus2->fifoFillLevelMsb & 0x07)) << 8);
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Check if the FIFO is empty
+ * @param[out] empty FIFO empty state
+ * @retval Error code
+ */
+int8_t ISDS_isFifoEmpty(ISDS_state_t *empty)
+{
+  ISDS_fifoStatus2_t fifoStatus2;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_STATUS_2_REG, 1, (uint8_t *) &fifoStatus2))
+  {
+    return WE_FAIL;
+  }
+
+  *empty = (ISDS_state_t) fifoStatus2.fifoEmptyState;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Check if the FIFO is full
+ * @param[out] full FIFO full state
+ * @retval Error code
+ */
+int8_t ISDS_isFifoFull(ISDS_state_t *full)
+{
+  ISDS_fifoStatus2_t fifoStatus2;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_STATUS_2_REG, 1, (uint8_t *) &fifoStatus2))
+  {
+    return WE_FAIL;
+  }
+
+  *full = (ISDS_state_t) fifoStatus2.fifoFullSmartState;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Check if a FIFO overrun has occurred
+ * @param[out] overrun FIFO overrun state
+ * @retval Error code
+ */
+int8_t ISDS_getFifoOverrunState(ISDS_state_t *overrun)
+{
+  ISDS_fifoStatus2_t fifoStatus2;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_STATUS_2_REG, 1, (uint8_t *) &fifoStatus2))
+  {
+    return WE_FAIL;
+  }
+
+  *overrun = (ISDS_state_t) fifoStatus2.fifoOverrunState;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Check if the FIFO fill threshold has been reached
+ * @param[out] threshReached FIFO threshold status bit
+ * @retval Error code
+ */
+int8_t ISDS_isFifoThresholdReached(ISDS_state_t *threshReached)
+{
+  ISDS_fifoStatus2_t fifoStatus2;
+
+  if (WE_FAIL == ReadReg(ISDS_FIFO_STATUS_2_REG, 1, (uint8_t *) &fifoStatus2))
+  {
+    return WE_FAIL;
+  }
+
+  *threshReached = (ISDS_state_t) fifoStatus2.fifoThresholdState;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Get the word of recursive pattern read at the next read
+ * @param[out] fifoPattern Word of recursive pattern read at the next read
+ * @retval Error code
+ */
+int8_t ISDS_getFifoPattern(uint16_t *fifoPattern)
+{
+  uint8_t tmp[2];
+  if (WE_FAIL == ReadReg(ISDS_FIFO_STATUS_3_REG, 2, tmp))
+  {
+    return WE_FAIL;
+  }
+
+  ISDS_fifoStatus3_t *fifoStatus3 = (ISDS_fifoStatus3_t *) tmp;
+  ISDS_fifoStatus4_t *fifoStatus4 = (ISDS_fifoStatus4_t *) tmp + 1;
+
+  *fifoPattern = ((uint16_t) fifoStatus3->fifoPatternLsb) |
+                 (((uint16_t) (fifoStatus4->fifoPatternMsb & 0x03)) << 8);
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_FUNC_SRC_1_REG */
+
+/**
+ * @brief Check if a tilt event has occurred
+ * @param[out] tiltEvent Tilt event state
+ * @retval Error code
+ */
+int8_t ISDS_isTiltEvent(ISDS_state_t *tiltEvent)
+{
+  ISDS_funcSrc1_t funcSrc1;
+
+  if (WE_FAIL == ReadReg(ISDS_FUNC_SRC_1_REG, 1, (uint8_t *) &funcSrc1))
+  {
+    return WE_FAIL;
+  }
+
+  *tiltEvent = (ISDS_state_t) funcSrc1.tiltState;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_TAP_CFG_REG */
+
+/**
+ * @brief Enable/disable latched interrupts
+ * @param[in] lir Latched interrupts state
+ * @retval Error code
+ */
+int8_t ISDS_enableLatchedInterrupt(ISDS_state_t lir)
+{
+  ISDS_tapCfg_t tapCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg))
+  {
+    return WE_FAIL;
+  }
+
+  tapCfg.latchedInterrupt = lir;
+
+  return WriteReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg);
+}
+
+/**
+ * @brief Read the latched interrupts state [enabled, disabled]
+ * @param[out] lir The returned latched interrupts state
+ * @retval Error code
+ */
+int8_t ISDS_isLatchedInterruptEnabled(ISDS_state_t *lir)
+{
+  ISDS_tapCfg_t tapCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg))
+  {
+    return WE_FAIL;
+  }
+
+  *lir = (ISDS_state_t) tapCfg.latchedInterrupt;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable tap recognition in X direction
+ * @param[in] tapX Tap X direction state
+ * @retval Error code
+ */
+int8_t ISDS_enableTapX(ISDS_state_t tapX)
+{
+  ISDS_tapCfg_t tapCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg))
+  {
+    return WE_FAIL;
+  }
+
+  tapCfg.enTapX = tapX;
+
+  return WriteReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg);
+}
+
+/**
+ * @brief Check if detection of tap events in X direction is enabled
+ * @param[out] tapX The returned tap X direction state
+ * @retval Error code
+ */
+int8_t ISDS_isTapXEnabled(ISDS_state_t *tapX)
+{
+  ISDS_tapCfg_t tapCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg))
+  {
+    return WE_FAIL;
+  }
+
+  *tapX = (ISDS_state_t) tapCfg.enTapX;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable tap recognition in Y direction
+ * @param[in] tapY Tap Y direction state
+ * @retval Error code
+ */
+int8_t ISDS_enableTapY(ISDS_state_t tapY)
+{
+  ISDS_tapCfg_t tapCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg))
+  {
+    return WE_FAIL;
+  }
+
+  tapCfg.enTapY = tapY;
+
+  return WriteReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg);
+}
+
+/**
+ * @brief Check if detection of tap events in Y direction is enabled
+ * @param[out] tapY The returned tap Y direction state
+ * @retval Error code
+ */
+int8_t ISDS_isTapYEnabled(ISDS_state_t *tapY)
+{
+  ISDS_tapCfg_t tapCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg))
+  {
+    return WE_FAIL;
+  }
+
+  *tapY = (ISDS_state_t) tapCfg.enTapY;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable tap recognition in Z direction
+ * @param[in] tapZ Tap Z direction state
+ * @retval Error code
+ */
+int8_t ISDS_enableTapZ(ISDS_state_t tapZ)
+{
+  ISDS_tapCfg_t tapCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg))
+  {
+    return WE_FAIL;
+  }
+
+  tapCfg.enTapZ = tapZ;
+
+  return WriteReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg);
+}
+
+/**
+ * @brief Check if detection of tap events in Z direction is enabled
+ * @param[out] tapZ The returned tap Z direction state
+ * @retval Error code
+ */
+int8_t ISDS_isTapZEnabled(ISDS_state_t *tapZ)
+{
+  ISDS_tapCfg_t tapCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg))
+  {
+    return WE_FAIL;
+  }
+
+  *tapZ = (ISDS_state_t) tapCfg.enTapZ;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set activity filter (HPF or SLOPE filter selection on wake-up and activity/inactivity functions)
+ * @param[in] filter Activity filter
+ * @retval Error code
+ */
+int8_t ISDS_setActivityFilter(ISDS_activityFilter_t filter)
+{
+  ISDS_tapCfg_t tapCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg))
+  {
+    return WE_FAIL;
+  }
+
+  tapCfg.filterSelection = filter;
+
+  return WriteReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg);
+}
+
+/**
+ * @brief Read activity filter (HPF or SLOPE filter selection on wake-up and activity/inactivity functions)
+ * @param[out] filter The returned activity filter
+ * @retval Error code
+ */
+int8_t ISDS_getActivityFilter(ISDS_activityFilter_t *filter)
+{
+  ISDS_tapCfg_t tapCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg))
+  {
+    return WE_FAIL;
+  }
+
+  *filter = (ISDS_activityFilter_t) tapCfg.filterSelection;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set inactivity function
+ * @param[in] function Inactivity function
+ * @retval Error code
+ */
+int8_t ISDS_setInactivityFunction(ISDS_inactivityFunction_t function)
+{
+  ISDS_tapCfg_t tapCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg))
+  {
+    return WE_FAIL;
+  }
+
+  tapCfg.enInactivity = function;
+
+  return WriteReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg);
+}
+
+/**
+ * @brief Read inactivity function
+ * @param[out] function The returned inactivity function
+ * @retval Error code
+ */
+int8_t ISDS_getInactivityFunction(ISDS_inactivityFunction_t *function)
+{
+  ISDS_tapCfg_t tapCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg))
+  {
+    return WE_FAIL;
+  }
+
+  *function = (ISDS_inactivityFunction_t) tapCfg.enInactivity;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable interrupts
+ * @param[in] interruptsEnable Interrupts enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableInterrupts(ISDS_state_t interruptsEnable)
+{
+  ISDS_tapCfg_t tapCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg))
+  {
+    return WE_FAIL;
+  }
+
+  tapCfg.enInterrupts = interruptsEnable;
+
+  return WriteReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg);
+}
+
+/**
+ * @brief Check if interrupts are enabled
+ * @param[out] interruptsEnable The returned interrupts enable state.
+ * @retval Error code
+ */
+int8_t ISDS_areInterruptsEnabled(ISDS_state_t *interruptsEnable)
+{
+  ISDS_tapCfg_t tapCfg;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_CFG_REG, 1, (uint8_t *) &tapCfg))
+  {
+    return WE_FAIL;
+  }
+
+  *interruptsEnable = (ISDS_state_t) tapCfg.enInterrupts;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_TAP_THS_6D_REG */
+
+/**
+ * @brief Set the tap threshold
+ * @param[in] tapThreshold Tap threshold (5 bits)
+ * @retval Error code
+ */
+int8_t ISDS_setTapThreshold(uint8_t tapThreshold)
+{
+  ISDS_tapThs6d_t tapThs6d;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_THS_6D_REG, 1, (uint8_t *) &tapThs6d))
+  {
+    return WE_FAIL;
+  }
+
+  tapThs6d.tapThreshold = (tapThreshold & 0x1F);
+
+  return WriteReg(ISDS_TAP_THS_6D_REG, 1, (uint8_t *) &tapThs6d);
+}
+
+/**
+ * @brief Read the tap threshold
+ * @param[out] tapThreshold The returned tap threshold
+ * @retval Error code
+ */
+int8_t ISDS_getTapThreshold(uint8_t *tapThreshold)
+{
+  ISDS_tapThs6d_t tapThs6d;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_THS_6D_REG, 1, (uint8_t *) &tapThs6d))
+  {
+    return WE_FAIL;
+  }
+
+  *tapThreshold = tapThs6d.tapThreshold;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the 6D orientation detection threshold (degrees)
+ * @param[in] threshold6D 6D orientation detection threshold
+ * @retval Error code
+ */
+int8_t ISDS_set6DThreshold(ISDS_sixDThreshold_t threshold6D)
+{
+  ISDS_tapThs6d_t tapThs6d;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_THS_6D_REG, 1, (uint8_t *) &tapThs6d))
+  {
+    return WE_FAIL;
+  }
+
+  tapThs6d.sixDThreshold = threshold6D;
+
+  return WriteReg(ISDS_TAP_THS_6D_REG, 1, (uint8_t *) &tapThs6d);
+}
+
+/**
+ * @brief Read the 6D orientation detection threshold (degrees)
+ * @param[out] threshold6D The returned 6D orientation detection threshold
+ * @retval Error code
+ */
+int8_t ISDS_get6DThreshold(ISDS_sixDThreshold_t *threshold6D)
+{
+  ISDS_tapThs6d_t tapThs6d;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_THS_6D_REG, 1, (uint8_t *) &tapThs6d))
+  {
+    return WE_FAIL;
+  }
+
+  *threshold6D = (ISDS_sixDThreshold_t) tapThs6d.sixDThreshold;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable 4D orientation detection
+ * @param[in] detection4D The 4D orientation detection enable state
+ * @retval Error code
+ */
+int8_t ISDS_enable4DDetection(ISDS_state_t detection4D)
+{
+  ISDS_tapThs6d_t tapThs6d;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_THS_6D_REG, 1, (uint8_t *) &tapThs6d))
+  {
+    return WE_FAIL;
+  }
+
+  tapThs6d.fourDDetectionEnabled = detection4D;
+
+  return WriteReg(ISDS_TAP_THS_6D_REG, 1, (uint8_t *) &tapThs6d);
+}
+
+/**
+ * @brief Check if 4D orientation detection is enabled
+ * @param[out] detection4D The returned 4D orientation detection enable state
+ * @retval Error code
+ */
+int8_t ISDS_is4DDetectionEnabled(ISDS_state_t *detection4D)
+{
+  ISDS_tapThs6d_t tapThs6d;
+
+  if (WE_FAIL == ReadReg(ISDS_TAP_THS_6D_REG, 1, (uint8_t *) &tapThs6d))
+  {
+    return WE_FAIL;
+  }
+
+  *detection4D = (ISDS_state_t) tapThs6d.fourDDetectionEnabled;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_INT_DUR2_REG */
+
+/**
+ * @brief Set the maximum duration time gap for double-tap recognition (LATENCY)
+ * @param[in] latencyTime Latency value (4 bits)
+ * @retval Error code
+ */
+int8_t ISDS_setTapLatencyTime(uint8_t latencyTime)
+{
+  ISDS_intDur2_t intDuration;
+
+  if (WE_FAIL == ReadReg(ISDS_INT_DUR2_REG, 1, (uint8_t *) &intDuration))
+  {
+    return WE_FAIL;
+  }
+
+  intDuration.latency = (latencyTime & 0x0F);
+
+  return WriteReg(ISDS_INT_DUR2_REG, 1, (uint8_t *) &intDuration);
+}
+
+/**
+ * @brief Read the maximum duration time gap for double-tap recognition (LATENCY)
+ * @param[out] latencyTime The returned latency time
+ * @retval Error code
+ */
+int8_t ISDS_getTapLatencyTime(uint8_t *latencyTime)
+{
+  ISDS_intDur2_t intDuration;
+
+  if (WE_FAIL == ReadReg(ISDS_INT_DUR2_REG, 1, (uint8_t *) &intDuration))
+  {
+    return WE_FAIL;
+  }
+
+  *latencyTime = intDuration.latency;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the expected quiet time after a tap detection (QUIET)
+ * @param[in] quietTime Quiet time value (2 bits)
+ * @retval Error code
+ */
+int8_t ISDS_setTapQuietTime(uint8_t quietTime)
+{
+  ISDS_intDur2_t intDuration;
+
+  if (WE_FAIL == ReadReg(ISDS_INT_DUR2_REG, 1, (uint8_t *) &intDuration))
+  {
+    return WE_FAIL;
+  }
+
+  intDuration.quiet = (quietTime & 0x03);
+
+  return WriteReg(ISDS_INT_DUR2_REG, 1, (uint8_t *) &intDuration);
+}
+
+/**
+ * @brief Read the expected quiet time after a tap detection (QUIET)
+ * @param[out] quietTime The returned quiet time
+ * @retval Error code
+ */
+int8_t ISDS_getTapQuietTime(uint8_t *quietTime)
+{
+
+  ISDS_intDur2_t intDuration;
+
+  if (WE_FAIL == ReadReg(ISDS_INT_DUR2_REG, 1, (uint8_t *) &intDuration))
+  {
+    return WE_FAIL;
+  }
+
+  *quietTime = intDuration.quiet;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the maximum duration of over-threshold events (SHOCK)
+ * @param[in] shockTime Shock time value (2 bits)
+ * @retval Error code
+ */
+int8_t ISDS_setTapShockTime(uint8_t shockTime)
+{
+  ISDS_intDur2_t intDuration;
+
+  if (WE_FAIL == ReadReg(ISDS_INT_DUR2_REG, 1, (uint8_t *) &intDuration))
+  {
+    return WE_FAIL;
+  }
+
+  intDuration.shock = (shockTime & 0x03);
+
+  return WriteReg(ISDS_INT_DUR2_REG, 1, (uint8_t *) &intDuration);
+}
+
+/**
+ * @brief Read the maximum duration of over-threshold events (SHOCK)
+ * @param[out] shockTime The returned shock time.
+ * @retval Error code
+ */
+int8_t ISDS_getTapShockTime(uint8_t *shockTime)
+{
+  ISDS_intDur2_t intDuration;
+
+  if (WE_FAIL == ReadReg(ISDS_INT_DUR2_REG, 1, (uint8_t *) &intDuration))
+  {
+    return WE_FAIL;
+  }
+
+  *shockTime = intDuration.shock;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_WAKE_UP_THS_REG */
+
+/**
+ * @brief Set wake-up threshold
+ * @param[in] thresh Wake-up threshold (six bits)
+ * @retval Error code
+ */
+int8_t ISDS_setWakeUpThreshold(uint8_t thresh)
+{
+  ISDS_wakeUpThs_t wakeUpThs;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_THS_REG, 1, (uint8_t *) &wakeUpThs))
+  {
+    return WE_FAIL;
+  }
+
+  wakeUpThs.wakeUpThreshold = (thresh & 0x3F);
+
+  return WriteReg(ISDS_WAKE_UP_THS_REG, 1, (uint8_t *) &wakeUpThs);
+}
+
+/**
+ * @brief Read the wake-up threshold
+ * @param[out] thresh The returned wake-up threshold.
+ * @retval Error code
+ */
+int8_t ISDS_getWakeUpThreshold(uint8_t *thresh)
+{
+  ISDS_wakeUpThs_t wakeUpThs;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_THS_REG, 1, (uint8_t *) &wakeUpThs))
+  {
+    return WE_FAIL;
+  }
+
+  *thresh = wakeUpThs.wakeUpThreshold;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the single and double-tap event OR only single-tap event
+ * @param[in] doubleTapEnable Tap event state [0: only single, 1: single and double-tap]
+ * @retval Error code
+ */
+int8_t ISDS_enableDoubleTapEvent(ISDS_state_t doubleTapEnable)
+{
+  ISDS_wakeUpThs_t wakeUpThs;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_THS_REG, 1, (uint8_t *) &wakeUpThs))
+  {
+    return WE_FAIL;
+  }
+
+  wakeUpThs.enDoubleTapEvent = doubleTapEnable;
+
+  return WriteReg(ISDS_WAKE_UP_THS_REG, 1, (uint8_t *) &wakeUpThs);
+}
+
+/**
+ * @brief Check if double-tap events are enabled
+ * @param[out] doubleTap The returned tap event state [0: only single, 1: single and double-tap]
+ * @retval Error code
+ */
+int8_t ISDS_isDoubleTapEventEnabled(ISDS_state_t *doubleTapEnable)
+{
+  ISDS_wakeUpThs_t wakeUpThs;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_THS_REG, 1, (uint8_t *) &wakeUpThs))
+  {
+    return WE_FAIL;
+  }
+
+  *doubleTapEnable = (ISDS_state_t) wakeUpThs.enDoubleTapEvent;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_WAKE_UP_DUR_REG */
+
+/**
+ * @brief Set the sleep mode duration
+ * @param[in] duration Sleep mode duration (4 bits)
+ * @retval Error code
+ */
+int8_t ISDS_setSleepDuration(uint8_t duration)
+{
+  ISDS_wakeUpDur_t wakeUpDur;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_DUR_REG, 1, (uint8_t *) &wakeUpDur))
+  {
+    return WE_FAIL;
+  }
+
+  wakeUpDur.sleepDuration = (duration & 0x0F);
+
+  return WriteReg(ISDS_WAKE_UP_DUR_REG, 1, (uint8_t *) &wakeUpDur);
+}
+
+/**
+ * @brief Read the sleep mode duration
+ * @param[out] duration The returned sleep mode duration
+ * @retval Error code
+ */
+int8_t ISDS_getSleepDuration(uint8_t *duration)
+{
+  ISDS_wakeUpDur_t wakeUpDur;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_DUR_REG, 1, (uint8_t *) &wakeUpDur))
+  {
+    return WE_FAIL;
+  }
+
+  *duration = wakeUpDur.sleepDuration;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the timestamp register resolution
+ * @param[in] resolution Timestamp register resolution
+ * @retval Error code
+ */
+int8_t ISDS_setTimestampResolution(ISDS_timestampResolution_t resolution)
+{
+  ISDS_wakeUpDur_t wakeUpDur;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_DUR_REG, 1, (uint8_t *) &wakeUpDur))
+  {
+    return WE_FAIL;
+  }
+
+  wakeUpDur.timestampResolution = resolution;
+
+  return WriteReg(ISDS_WAKE_UP_DUR_REG, 1, (uint8_t *) &wakeUpDur);
+}
+
+/**
+ * @brief Read the timestamp register resolution
+ * @param[out] resolution The returned timestamp register resolution
+ * @retval Error code
+ */
+int8_t ISDS_getTimestampResolution(ISDS_timestampResolution_t *resolution)
+{
+  ISDS_wakeUpDur_t wakeUpDur;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_DUR_REG, 1, (uint8_t *) &wakeUpDur))
+  {
+    return WE_FAIL;
+  }
+
+  *resolution = (ISDS_timestampResolution_t) wakeUpDur.timestampResolution;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set wake-up duration
+ * @param[in] duration Wake-up duration (two bits)
+ * @retval Error code
+ */
+int8_t ISDS_setWakeUpDuration(uint8_t duration)
+{
+  ISDS_wakeUpDur_t wakeUpDur;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_DUR_REG, 1, (uint8_t *) &wakeUpDur))
+  {
+    return WE_FAIL;
+  }
+
+  wakeUpDur.wakeUpDuration = (duration & 0x03);
+
+  return WriteReg(ISDS_WAKE_UP_DUR_REG, 1, (uint8_t *) &wakeUpDur);
+}
+
+/**
+ * @brief Read the wake-up duration
+ * @param[out] duration The returned wake-up duration (two bits)
+ * @retval Error code
+ */
+int8_t ISDS_getWakeUpDuration(uint8_t *duration)
+{
+  ISDS_wakeUpDur_t wakeUpDur;
+
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_DUR_REG, 1, (uint8_t *) &wakeUpDur))
+  {
+    return WE_FAIL;
+  }
+
+  *duration = wakeUpDur.wakeUpDuration;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_FREE_FALL_REG */
+
+/**
+ * @brief Set free-fall threshold
+ * @param[in] thresh Free-fall threshold value
+ * @retval Error code
+ */
+int8_t ISDS_setFreeFallThreshold(ISDS_freeFallThreshold_t thresh)
+{
+  ISDS_freeFall_t freeFall;
+
+  if (WE_FAIL == ReadReg(ISDS_FREE_FALL_REG, 1, (uint8_t *) &freeFall))
+  {
+    return WE_FAIL;
+  }
+
+  freeFall.freeFallThreshold = thresh;
+
+  return WriteReg(ISDS_FREE_FALL_REG, 1, (uint8_t *) &freeFall);
+}
+
+/**
+ * @brief Read the free-fall threshold
+ * @param[in] thresh The returned free-fall threshold value
+ * @retval Error code
+ */
+int8_t ISDS_getFreeFallThreshold(ISDS_freeFallThreshold_t *thresh)
+{
+  ISDS_freeFall_t freeFall;
+
+  if (WE_FAIL == ReadReg(ISDS_FREE_FALL_REG, 1, (uint8_t *) &freeFall))
+  {
+    return WE_FAIL;
+  }
+
+  *thresh = (ISDS_freeFallThreshold_t) freeFall.freeFallThreshold;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Set the free-fall duration (both LSB and MSB).
+ * @param[in] duration Free-fall duration (6 bits)
+ * @retval Error code
+ */
+int8_t ISDS_setFreeFallDuration(uint8_t duration)
+{
+  ISDS_freeFall_t freeFall;
+  ISDS_wakeUpDur_t wakeUpDur;
+
+  if (WE_FAIL == ReadReg(ISDS_FREE_FALL_REG, 1, (uint8_t *) &freeFall))
+  {
+    return WE_FAIL;
+  }
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_DUR_REG, 1, (uint8_t *) &wakeUpDur))
+  {
+    return WE_FAIL;
+  }
+
+  freeFall.freeFallDurationLSB = (uint8_t) (duration & 0x1F);
+  wakeUpDur.freeFallDurationMSB = (uint8_t) ((duration >> 5) & 0x01);
+
+  if (WE_FAIL == WriteReg(ISDS_FREE_FALL_REG, 1, (uint8_t *) &freeFall))
+  {
+    return WE_FAIL;
+  }
+  return WriteReg(ISDS_WAKE_UP_DUR_REG, 1, (uint8_t *) &wakeUpDur);
+}
+
+/**
+ * @brief Read the free-fall duration (both LSB and MSB).
+ * @param[out] duration The returned free-fall duration (6 bits)
+ * @retval Error code
+ */
+int8_t ISDS_getFreeFallDuration(uint8_t *duration)
+{
+  ISDS_freeFall_t freeFall;
+  ISDS_wakeUpDur_t wakeUpDur;
+
+  if (WE_FAIL == ReadReg(ISDS_FREE_FALL_REG, 1, (uint8_t *) &freeFall))
+  {
+    return WE_FAIL;
+  }
+  if (WE_FAIL == ReadReg(ISDS_WAKE_UP_DUR_REG, 1, (uint8_t *) &wakeUpDur))
+  {
+    return WE_FAIL;
+  }
+
+  *duration = ((uint8_t) freeFall.freeFallDurationLSB) |
+              (((uint8_t) (wakeUpDur.freeFallDurationMSB & 0x01)) << 5);
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_MD1_CFG_REG */
+
+/**
+ * @brief Enable/disable the timer end counter event interrupt on INT_0
+ * @param[in] int0Timer Timer end counter event interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableTimerEndCounterINT0(ISDS_state_t int0Timer)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  mde1Cfg.int0Timer = int0Timer;
+
+  return WriteReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg);
+}
+
+/**
+ * @brief Check if the timer end counter event interrupt on INT_0 is enabled
+ * @param[out] int0Timer The returned timer end counter event interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isTimerEndCounterINT0Enabled(ISDS_state_t *int0Timer)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  *int0Timer = (ISDS_state_t) mde1Cfg.int0Timer;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the tilt event interrupt on INT_0
+ * @param[in] int0Tilt Tilt event interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableTiltINT0(ISDS_state_t int0Tilt)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  mde1Cfg.int0Tilt = int0Tilt;
+
+  return WriteReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg);
+}
+
+/**
+ * @brief Check if the tilt event interrupt on INT_0 is enabled
+ * @param[out] int0Tilt The returned tilt event interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isTiltINT0Enabled(ISDS_state_t *int0Tilt)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  *int0Tilt = (ISDS_state_t) mde1Cfg.int0Tilt;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the 6D orientation change event interrupt on INT_0
+ * @param[in] int06d 6D orientation change event interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enable6dINT0(ISDS_state_t int06d)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  mde1Cfg.int06d = int06d;
+
+  return WriteReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg);
+}
+
+/**
+ * @brief Check if the 6D orientation change event interrupt on INT_0 is enabled
+ * @param[out] int06d The returned 6D orientation change event interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_is6dINT0Enabled(ISDS_state_t *int06d)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  *int06d = (ISDS_state_t) mde1Cfg.int06d;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the double-tap interrupt on INT_0
+ * @param[in] int0DoubleTap The double-tap interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableDoubleTapINT0(ISDS_state_t int0DoubleTap)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  mde1Cfg.int0DoubleTap = int0DoubleTap;
+
+  return WriteReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg);
+}
+
+/**
+ * @brief Check if the double-tap interrupt on INT_0 is enabled
+ * @param[out] int0DoubleTap The returned double-tap interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isDoubleTapINT0Enabled(ISDS_state_t *int0DoubleTap)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  *int0DoubleTap = (ISDS_state_t) mde1Cfg.int0DoubleTap;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the free-fall interrupt on INT_0
+ * @param[in] int0FreeFall Free-fall interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableFreeFallINT0(ISDS_state_t int0FreeFall)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  mde1Cfg.int0FreeFall = int0FreeFall;
+
+  return WriteReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg);
+}
+
+/**
+ * @brief Check if the free-fall interrupt on INT_0 is enabled
+ * @param[out] int0FreeFall The returned free-fall enable state
+ * @retval Error code
+ */
+int8_t ISDS_isFreeFallINT0Enabled(ISDS_state_t *int0FreeFall)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  *int0FreeFall = (ISDS_state_t) mde1Cfg.int0FreeFall;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the wake-up interrupt on INT_0
+ * @param[in] int0WakeUp Wake-up interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableWakeUpINT0(ISDS_state_t int0WakeUp)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  mde1Cfg.int0WakeUp = int0WakeUp;
+
+  return WriteReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg);
+}
+
+/**
+ * @brief Check if the wake-up interrupt on INT_0 is enabled
+ * @param[out] int0WakeUp The returned wake-up interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isWakeUpINT0Enabled(ISDS_state_t *int0WakeUp)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  *int0WakeUp = (ISDS_state_t) mde1Cfg.int0WakeUp;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the single-tap interrupt on INT_0
+ * @param[in] int0SingleTap Single-tap interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableSingleTapINT0(ISDS_state_t int0SingleTap)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  mde1Cfg.int0SingleTap = int0SingleTap;
+
+  return WriteReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg);
+}
+
+/**
+ * @brief Check if the single-tap interrupt on INT_0 is enabled
+ * @param[out] int0SingleTap The returned single-tap interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isSingleTapINT0Enabled(ISDS_state_t *int0SingleTap)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  *int0SingleTap = (ISDS_state_t) mde1Cfg.int0SingleTap;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the inactivity state interrupt on INT_0
+ * @param[in] int0InactivityState Inactivity state interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableInactivityStateINT0(ISDS_state_t int0InactivityState)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  mde1Cfg.int0InactivityState = int0InactivityState;
+
+  return WriteReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg);
+}
+
+/**
+ * @brief Check if the inactivity state interrupt on INT_0 is enabled
+ * @param[out] int0InactivityState The returned inactivity state interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isInactivityStateINT0Enabled(ISDS_state_t *int0InactivityState)
+{
+  ISDS_mde1Cfg_t mde1Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD1_CFG_REG, 1, (uint8_t *) &mde1Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  *int0InactivityState = (ISDS_state_t) mde1Cfg.int0InactivityState;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_MD2_CFG_REG */
+
+/**
+ * @brief Enable/disable the tilt event interrupt on INT_1
+ * @param[in] int1Tilt Tilt event interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableTiltINT1(ISDS_state_t int1Tilt)
+{
+  ISDS_mde2Cfg_t mde2Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  mde2Cfg.int1Tilt = int1Tilt;
+
+  return WriteReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg);
+}
+
+/**
+ * @brief Check if the tilt event interrupt on INT_1 is enabled
+ * @param[out] int1Tilt The returned tilt event interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isTiltINT1Enabled(ISDS_state_t *int1Tilt)
+{
+  ISDS_mde2Cfg_t mde2Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  *int1Tilt = (ISDS_state_t) mde2Cfg.int1Tilt;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the 6D orientation change event interrupt on INT_1
+ * @param[in] int16d 6D orientation change event interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enable6dINT1(ISDS_state_t int16d)
+{
+  ISDS_mde2Cfg_t mde2Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  mde2Cfg.int16d = int16d;
+
+  return WriteReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg);
+}
+
+/**
+ * @brief Check if the 6D orientation change event interrupt on INT_1 is enabled
+ * @param[out] int16d The returned 6D orientation change event interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_is6dINT1Enabled(ISDS_state_t *int16d)
+{
+  ISDS_mde2Cfg_t mde2Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  *int16d = (ISDS_state_t) mde2Cfg.int16d;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the double-tap interrupt on INT_1
+ * @param[in] int1DoubleTap The double-tap interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableDoubleTapINT1(ISDS_state_t int1DoubleTap)
+{
+  ISDS_mde2Cfg_t mde2Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  mde2Cfg.int1DoubleTap = int1DoubleTap;
+
+  return WriteReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg);
+}
+
+/**
+ * @brief Check if the double-tap interrupt on INT_1 is enabled
+ * @param[out] int1DoubleTap The returned double-tap interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isDoubleTapINT1Enabled(ISDS_state_t *int1DoubleTap)
+{
+  ISDS_mde2Cfg_t mde2Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  *int1DoubleTap = (ISDS_state_t) mde2Cfg.int1DoubleTap;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the free-fall interrupt on INT_1
+ * @param[in] int1FreeFall Free-fall interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableFreeFallINT1(ISDS_state_t int1FreeFall)
+{
+  ISDS_mde2Cfg_t mde2Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  mde2Cfg.int1FreeFall = int1FreeFall;
+
+  return WriteReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg);
+}
+
+/**
+ * @brief Check if the free-fall interrupt on INT_1 is enabled
+ * @param[out] int1FreeFall The returned free-fall enable state
+ * @retval Error code
+ */
+int8_t ISDS_isFreeFallINT1Enabled(ISDS_state_t *int1FreeFall)
+{
+  ISDS_mde2Cfg_t mde2Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  *int1FreeFall = (ISDS_state_t) mde2Cfg.int1FreeFall;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the wake-up interrupt on INT_1
+ * @param[in] int1WakeUp Wake-up interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableWakeUpINT1(ISDS_state_t int1WakeUp)
+{
+  ISDS_mde2Cfg_t mde2Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  mde2Cfg.int1WakeUp = int1WakeUp;
+
+  return WriteReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg);
+}
+
+/**
+ * @brief Check if the wake-up interrupt on INT_1 is enabled
+ * @param[out] int1WakeUp The returned wake-up interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isWakeUpINT1Enabled(ISDS_state_t *int1WakeUp)
+{
+  ISDS_mde2Cfg_t mde2Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  *int1WakeUp = (ISDS_state_t) mde2Cfg.int1WakeUp;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the single-tap interrupt on INT_1
+ * @param[in] int1SingleTap Single-tap interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableSingleTapINT1(ISDS_state_t int1SingleTap)
+{
+  ISDS_mde2Cfg_t mde2Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  mde2Cfg.int1SingleTap = int1SingleTap;
+
+  return WriteReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg);
+}
+
+/**
+ * @brief Check if the single-tap interrupt on INT_1 is enabled
+ * @param[out] int1SingleTap The returned single-tap interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isSingleTapINT1Enabled(ISDS_state_t *int1SingleTap)
+{
+  ISDS_mde2Cfg_t mde2Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  *int1SingleTap = (ISDS_state_t) mde2Cfg.int1SingleTap;
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Enable/disable the inactivity state interrupt on INT_1
+ * @param[in] int1InactivityState Inactivity state interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_enableInactivityStateINT1(ISDS_state_t int1InactivityState)
+{
+  ISDS_mde2Cfg_t mde2Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  mde2Cfg.int1InactivityState = int1InactivityState;
+
+  return WriteReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg);
+}
+
+/**
+ * @brief Check if the inactivity state interrupt on INT_1 is enabled
+ * @param[out] int1InactivityState The returned inactivity state interrupt enable state
+ * @retval Error code
+ */
+int8_t ISDS_isInactivityStateINT1Enabled(ISDS_state_t *int1InactivityState)
+{
+  ISDS_mde2Cfg_t mde2Cfg;
+
+  if (WE_FAIL == ReadReg(ISDS_MD2_CFG_REG, 1, (uint8_t *) &mde2Cfg))
+  {
+    return WE_FAIL;
+  }
+
+  *int1InactivityState = (ISDS_state_t) mde2Cfg.int1InactivityState;
+
+  return WE_SUCCESS;
+}
+
+
+/* ISDS_TIMESTAMP#_REG */
+
+/**
+ * @brief Read the current timestamp
+ *
+ * Note that the integrity of the timestamp cannot be guaranteed (the
+ * 8-bit words of the timestamp might be overwritten while reading).
+ *
+ * @param[out] timestamp Current timestamp (24 bits)
+ * @retval Error code
+ */
+int8_t ISDS_getTimestamp(uint32_t *timestamp)
+{
+  uint8_t tmp[3] = {0};
+
+  if (WE_FAIL == ReadReg(ISDS_TIMESTAMP0_REG, 3, tmp))
+  {
+    return WE_FAIL;
+  }
+
+  *timestamp = (((uint32_t) tmp[2]) << 16) |
+      (((uint32_t) tmp[1]) << 8) |
+      ((uint32_t) tmp[0]);
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Reset the timestamp counter to zero
+ * @retval Error code
+ */
+int8_t ISDS_resetTimestampCounter()
+{
+  uint8_t resetCommand = 0xAA;
+  return WriteReg(ISDS_TIMESTAMP2_REG, 1, &resetCommand);
+}
+
+
+/* ISDS_X_OFS_USR_REG */
+/* ISDS_Y_OFS_USR_REG */
+/* ISDS_Z_OFS_USR_REG */
+
+/**
+ * @brief Set the user offset for axis X
+ * @param[in] offsetValueXAxis User offset for axis X
+ * @retval Error code
+ */
+int8_t ISDS_setOffsetValueX(int8_t offsetValueXAxis)
+{
+  return WriteReg(ISDS_X_OFS_USR_REG, 1, (uint8_t *) &offsetValueXAxis);
+}
+
+/**
+ * @brief Read the user offset for axis X
+ * @param[out] offsetValueXAxis The returned user offset for axis X
+ * @retval Error code
+ */
+int8_t ISDS_getOffsetValueX(int8_t *offsetValueXAxis)
+{
+  return ReadReg(ISDS_X_OFS_USR_REG, 1, (uint8_t *) offsetValueXAxis);
+}
+
+/**
+ * @brief Set the user offset for axis Y
+ * @param[in] offsetValueYAxis User offset for axis Y
+ * @retval Error code
+ */
+int8_t ISDS_setOffsetValueY(int8_t offsetValueYAxis)
+{
+  return WriteReg(ISDS_Y_OFS_USR_REG, 1, (uint8_t *) &offsetValueYAxis);
+}
+
+/**
+ * @brief Read the user offset for axis Y
+ * @param[out] offsetValueYAxis The returned user offset for axis Y
+ * @retval Error code
+ */
+int8_t ISDS_getOffsetValueY(int8_t *offsetValueYAxis)
+{
+  return ReadReg(ISDS_Y_OFS_USR_REG, 1, (uint8_t *) offsetValueYAxis);
+}
+
+/**
+ * @brief Set the user offset for axis Z
+ * @param[in] offsetValueZAxis The user offset for axis Z
+ * @retval Error code
+ */
+int8_t ISDS_setOffsetValueZ(int8_t offsetValueZAxis)
+{
+  return WriteReg(ISDS_Z_OFS_USR_REG, 1, (uint8_t *) &offsetValueZAxis);
+}
+
+/**
+ * @brief Read the user offset for axis Z
+ * @param[out] offsetValueZAxis The returned user offset for axis Z
+ * @retval Error code
+ */
+int8_t ISDS_getOffsetValueZ(int8_t *offsetValueZAxis)
+{
+  return ReadReg(ISDS_Z_OFS_USR_REG, 1, (uint8_t *) offsetValueZAxis);
+}
+
+
+/* ISDS_FIFO_DATA_OUT_L_REG */
+/* ISDS_FIFO_DATA_OUT_H_REG */
+
+/**
+ * @brief Reads the specified number of 16 bit values from the FIFO buffer
+ *
+ * The type of values read depends on the FIFO configuration and the current
+ * read position. Get the current FIFO pattern value (e.g. via
+ * ISDS_getFifoPattern() or ISDS_getFifoStatus()). Before reading FIFO data to
+ * determine the type of the next value read.
+ *
+ * @param[in] numSamples The number of values to be read
+ * @param[out] fifoData The returned values (must provide pointer to buffer of length numSamples)
+ * @retval Error code
+ */
+int8_t ISDS_getFifoData(uint16_t numSamples, uint16_t *fifoData)
+{
+  return ReadReg(ISDS_FIFO_DATA_OUT_L_REG, numSamples * 2, (uint8_t *) fifoData);
+}
+
+
+#ifdef WE_USE_FLOAT
+/**
+ * @brief Reads the X-axis angular rate in [mdps]
+ *
+ * Note that this functions relies on the current gyroscope full scale value.
+ * Make sure that the current gyroscope full scale value is known by calling
+ * ISDS_setGyroFullScale() or ISDS_getGyroFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] xRate X-axis angular rate in [mdps]
+ * @retval Error code
+ */
+int8_t ISDS_getAngularRateX_float(float *xRate)
+{
+  int16_t rawRate;
+  if (WE_FAIL == ISDS_getRawAngularRateX(&rawRate))
+  {
+    return WE_FAIL;
+  }
+  *xRate = ISDS_convertAngularRate_float(rawRate, currentGyroFullScale);
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Reads the Y-axis angular rate in [mdps]
+ *
+ * Note that this functions relies on the current gyroscope full scale value.
+ * Make sure that the current gyroscope full scale value is known by calling
+ * ISDS_setGyroFullScale() or ISDS_getGyroFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] yRate Y-axis angular rate in [mdps]
+ * @retval Error code
+ */
+int8_t ISDS_getAngularRateY_float(float *yRate)
+{
+  int16_t rawRate;
+  if (WE_FAIL == ISDS_getRawAngularRateY(&rawRate))
+  {
+    return WE_FAIL;
+  }
+  *yRate = ISDS_convertAngularRate_float(rawRate, currentGyroFullScale);
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Reads the Z-axis angular rate in [mdps]
+ *
+ * Note that this functions relies on the current gyroscope full scale value.
+ * Make sure that the current gyroscope full scale value is known by calling
+ * ISDS_setGyroFullScale() or ISDS_getGyroFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] zRate Z-axis angular rate in [mdps]
+ * @retval Error code
+ */
+int8_t ISDS_getAngularRateZ_float(float *zRate)
+{
+  int16_t rawRate;
+  if (WE_FAIL == ISDS_getRawAngularRateZ(&rawRate))
+  {
+    return WE_FAIL;
+  }
+  *zRate = ISDS_convertAngularRate_float(rawRate, currentGyroFullScale);
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the gyroscope sensor output in [mdps] for all three axes
+ *
+ * Note that this functions relies on the current gyroscope full scale value.
+ * Make sure that the current gyroscope full scale value is known by calling
+ * ISDS_setGyroFullScale() or ISDS_getGyroFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] xRate The returned X-axis angular rate in [mdps]
+ * @param[out] yRate The returned Y-axis angular rate in [mdps]
+ * @param[out] zRate The returned Z-axis angular rate in [mdps]
+ * @retval Error code
+ */
+int8_t ISDS_getAngularRates_float(float *xRate, float *yRate, float *zRate)
+{
+  int16_t xRawRate, yRawRate, zRawRate;
+  if (WE_FAIL == ISDS_getRawAngularRates(&xRawRate, &yRawRate, &zRawRate))
+  {
+    return WE_FAIL;
+  }
+  *xRate = ISDS_convertAngularRate_float(xRawRate, currentGyroFullScale);
+  *yRate = ISDS_convertAngularRate_float(yRawRate, currentGyroFullScale);
+  *zRate = ISDS_convertAngularRate_float(zRawRate, currentGyroFullScale);
+  return WE_SUCCESS;
+}
+#endif /* WE_USE_FLOAT */
+
+/**
+ * @brief Reads the X-axis angular rate in [mdps]
+ *
+ * Note that this functions relies on the current gyroscope full scale value.
+ * Make sure that the current gyroscope full scale value is known by calling
+ * ISDS_setGyroFullScale() or ISDS_getGyroFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] xRate X-axis angular rate in [mdps]
+ * @retval Error code
+ */
+int8_t ISDS_getAngularRateX_int(int32_t *xRate)
+{
+  int16_t rawRate;
+  if (WE_FAIL == ISDS_getRawAngularRateX(&rawRate))
+  {
+    return WE_FAIL;
+  }
+  *xRate = ISDS_convertAngularRate_int(rawRate, currentGyroFullScale);
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Reads the Y-axis angular rate in [mdps]
+ *
+ * Note that this functions relies on the current gyroscope full scale value.
+ * Make sure that the current gyroscope full scale value is known by calling
+ * ISDS_setGyroFullScale() or ISDS_getGyroFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] yRate Y-axis angular rate in [mdps]
+ * @retval Error code
+ */
+int8_t ISDS_getAngularRateY_int(int32_t *yRate)
+{
+  int16_t rawRate;
+  if (WE_FAIL == ISDS_getRawAngularRateY(&rawRate))
+  {
+    return WE_FAIL;
+  }
+  *yRate = ISDS_convertAngularRate_int(rawRate, currentGyroFullScale);
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Reads the Z-axis angular rate in [mdps]
+ *
+ * Note that this functions relies on the current gyroscope full scale value.
+ * Make sure that the current gyroscope full scale value is known by calling
+ * ISDS_setGyroFullScale() or ISDS_getGyroFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] zRate Z-axis angular rate in [mdps]
+ * @retval Error code
+ */
+int8_t ISDS_getAngularRateZ_int(int32_t *zRate)
+{
+  int16_t rawRate;
+  if (WE_FAIL == ISDS_getRawAngularRateZ(&rawRate))
+  {
+    return WE_FAIL;
+  }
+  *zRate = ISDS_convertAngularRate_int(rawRate, currentGyroFullScale);
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the gyroscope sensor output in [mdps] for all three axes
+ *
+ * Note that this functions relies on the current gyroscope full scale value.
+ * Make sure that the current gyroscope full scale value is known by calling
+ * ISDS_setGyroFullScale() or ISDS_getGyroFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] xRate The returned X-axis angular rate in [mdps]
+ * @param[out] yRate The returned Y-axis angular rate in [mdps]
+ * @param[out] zRate The returned Z-axis angular rate in [mdps]
+ * @retval Error code
+ */
+int8_t ISDS_getAngularRates_int(int32_t *xRate, int32_t *yRate, int32_t *zRate)
+{
+  int16_t xRawRate, yRawRate, zRawRate;
+  if (WE_FAIL == ISDS_getRawAngularRates(&xRawRate, &yRawRate, &zRawRate))
+  {
+    return WE_FAIL;
+  }
+  *xRate = ISDS_convertAngularRate_int(xRawRate, currentGyroFullScale);
+  *yRate = ISDS_convertAngularRate_int(yRawRate, currentGyroFullScale);
+  *zRate = ISDS_convertAngularRate_int(zRawRate, currentGyroFullScale);
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the raw X-axis gyroscope sensor output
+ * @param[out] xRawAcc The returned raw X-axis angular rate
+ * @retval Error code
+ */
+int8_t ISDS_getRawAngularRateX(int16_t *xRawRate)
+{
+  uint8_t tmp[2] = {0};
+
+  if (WE_FAIL == ReadReg(ISDS_X_OUT_L_GYRO_REG, 2, tmp))
+  {
+    return WE_FAIL;
+  }
+
+  *xRawRate = (int16_t) (tmp[1] << 8);
+  *xRawRate |= (int16_t) tmp[0];
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the raw Y-axis gyroscope sensor output
+ * @param[out] yRawRate The returned raw Y-axis angular rate
+ * @retval Error code
+ */
+int8_t ISDS_getRawAngularRateY(int16_t *yRawRate)
+{
+  uint8_t tmp[2] = {0};
+
+  if (WE_FAIL == ReadReg(ISDS_Y_OUT_L_GYRO_REG, 2, tmp))
+  {
+    return WE_FAIL;
+  }
+
+  *yRawRate = (int16_t) (tmp[1] << 8);
+  *yRawRate |= (int16_t) tmp[0];
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the raw Z-axis gyroscope sensor output
+ * @param[out] zRawAcc The returned raw Z-axis angular rate
+ * @retval Error code
+ */
+int8_t ISDS_getRawAngularRateZ(int16_t *zRawRate)
+{
+  uint8_t tmp[2] = {0};
+
+  if (WE_FAIL == ReadReg(ISDS_Z_OUT_L_GYRO_REG, 2, tmp))
+  {
+    return WE_FAIL;
+  }
+
+  *zRawRate = (int16_t) (tmp[1] << 8);
+  *zRawRate |= (int16_t) tmp[0];
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the raw gyroscope sensor output for all three axes
+ * @param[out] xRawRate The returned raw X-axis angular rate
+ * @param[out] yRawRate The returned raw Y-axis angular rate
+ * @param[out] zRawRate The returned raw Z-axis angular rate
+ * @retval Error code
+ */
+int8_t ISDS_getRawAngularRates(int16_t *xRawRate, int16_t *yRawRate, int16_t *zRawRate)
+{
+  uint8_t tmp[6] = {0};
+
+  if (WE_FAIL == ReadReg(ISDS_X_OUT_L_GYRO_REG, 6, tmp))
+  {
+    return WE_FAIL;
+  }
+
+  *xRawRate = (int16_t) (tmp[1] << 8);
+  *xRawRate |= (int16_t) tmp[0];
+
+  *yRawRate = (int16_t) (tmp[3] << 8);
+  *yRawRate |= (int16_t) tmp[2];
+
+  *zRawRate = (int16_t) (tmp[5] << 8);
+  *zRawRate |= (int16_t) tmp[4];
+
+  return WE_SUCCESS;
+}
+
+#ifdef WE_USE_FLOAT
+/**
+ * @brief Read the X-axis acceleration in [mg]
+ *
+ * Note that this functions relies on the current accelerometer full scale value.
+ * Make sure that the current accelerometer full scale value is known by calling
+ * ISDS_setAccFullScale() or ISDS_getAccFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] xAcc X-axis acceleration in [mg]
+ * @retval Error code
+ */
+int8_t ISDS_getAccelerationX_float(float *xAcc)
+{
+  int16_t rawAcc;
+  if (WE_FAIL == ISDS_getRawAccelerationX(&rawAcc))
+  {
+    return WE_FAIL;
+  }
+  *xAcc = ISDS_convertAcceleration_float(rawAcc, currentAccFullScale);
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the Y-axis acceleration in [mg]
+ *
+ * Note that this functions relies on the current accelerometer full scale value.
+ * Make sure that the current accelerometer full scale value is known by calling
+ * ISDS_setAccFullScale() or ISDS_getAccFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] yAcc Y-axis acceleration in [mg]
+ * @retval Error code
+ */
+int8_t ISDS_getAccelerationY_float(float *yAcc)
+{
+  int16_t rawAcc;
+  if (WE_FAIL == ISDS_getRawAccelerationY(&rawAcc))
+  {
+    return WE_FAIL;
+  }
+  *yAcc = ISDS_convertAcceleration_float(rawAcc, currentAccFullScale);
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the Z-axis acceleration in [mg]
+ *
+ * Note that this functions relies on the current accelerometer full scale value.
+ * Make sure that the current accelerometer full scale value is known by calling
+ * ISDS_setAccFullScale() or ISDS_getAccFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] zAcc Z-axis acceleration in [mg]
+ * @retval Error code
+ */
+int8_t ISDS_getAccelerationZ_float(float *zAcc)
+{
+  int16_t rawAcc;
+  if (WE_FAIL == ISDS_getRawAccelerationZ(&rawAcc))
+  {
+    return WE_FAIL;
+  }
+  *zAcc = ISDS_convertAcceleration_float(rawAcc, currentAccFullScale);
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the accelerometer sensor output in [mg] for all three axes
+ *
+ * Note that this functions relies on the current accelerometer full scale value.
+ * Make sure that the current accelerometer full scale value is known by calling
+ * ISDS_setAccFullScale() or ISDS_getAccFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] xAcc The returned X-axis acceleration in [mg]
+ * @param[out] yAcc The returned Y-axis acceleration in [mg]
+ * @param[out] zAcc The returned Z-axis acceleration in [mg]
+ * @retval Error code
+ */
+int8_t ISDS_getAccelerations_float(float *xAcc, float *yAcc, float *zAcc)
+{
+  int16_t xRawAcc, yRawAcc, zRawAcc;
+  if (WE_FAIL == ISDS_getRawAccelerations(&xRawAcc, &yRawAcc, &zRawAcc))
+  {
+    return WE_FAIL;
+  }
+  *xAcc = ISDS_convertAcceleration_float(xRawAcc, currentAccFullScale);
+  *yAcc = ISDS_convertAcceleration_float(yRawAcc, currentAccFullScale);
+  *zAcc = ISDS_convertAcceleration_float(zRawAcc, currentAccFullScale);
+  return WE_SUCCESS;
+}
+#endif /* WE_USE_FLOAT */
+
+/**
+ * @brief Read the X-axis acceleration in [mg]
+ *
+ * Note that this functions relies on the current accelerometer full scale value.
+ * Make sure that the current accelerometer full scale value is known by calling
+ * ISDS_setAccFullScale() or ISDS_getAccFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] xAcc X-axis acceleration in [mg]
+ * @retval Error code
+ */
+int8_t ISDS_getAccelerationX_int(int16_t *xAcc)
+{
+  int16_t rawAcc;
+  if (WE_FAIL == ISDS_getRawAccelerationX(&rawAcc))
+  {
+    return WE_FAIL;
+  }
+  *xAcc = ISDS_convertAcceleration_int(rawAcc, currentAccFullScale);
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the Y-axis acceleration in [mg]
+ *
+ * Note that this functions relies on the current accelerometer full scale value.
+ * Make sure that the current accelerometer full scale value is known by calling
+ * ISDS_setAccFullScale() or ISDS_getAccFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] yAcc Y-axis acceleration in [mg]
+ * @retval Error code
+ */
+int8_t ISDS_getAccelerationY_int(int16_t *yAcc)
+{
+  int16_t rawAcc;
+  if (WE_FAIL == ISDS_getRawAccelerationY(&rawAcc))
+  {
+    return WE_FAIL;
+  }
+  *yAcc = ISDS_convertAcceleration_int(rawAcc, currentAccFullScale);
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the Z-axis acceleration in [mg]
+ *
+ * Note that this functions relies on the current accelerometer full scale value.
+ * Make sure that the current accelerometer full scale value is known by calling
+ * ISDS_setAccFullScale() or ISDS_getAccFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] zAcc Z-axis acceleration in [mg]
+ * @retval Error code
+ */
+int8_t ISDS_getAccelerationZ_int(int16_t *zAcc)
+{
+  int16_t rawAcc;
+  if (WE_FAIL == ISDS_getRawAccelerationZ(&rawAcc))
+  {
+    return WE_FAIL;
+  }
+  *zAcc = ISDS_convertAcceleration_int(rawAcc, currentAccFullScale);
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the accelerometer sensor output in [mg] for all three axes
+ *
+ * Note that this functions relies on the current accelerometer full scale value.
+ * Make sure that the current accelerometer full scale value is known by calling
+ * ISDS_setAccFullScale() or ISDS_getAccFullScale() at least once prior to
+ * calling this function.
+ *
+ * @param[out] xAcc The returned X-axis acceleration in [mg]
+ * @param[out] yAcc The returned Y-axis acceleration in [mg]
+ * @param[out] zAcc The returned Z-axis acceleration in [mg]
+ * @retval Error code
+ */
+int8_t ISDS_getAccelerations_int(int16_t *xAcc, int16_t *yAcc, int16_t *zAcc)
+{
+  int16_t xRawAcc, yRawAcc, zRawAcc;
+  if (WE_FAIL == ISDS_getRawAccelerations(&xRawAcc, &yRawAcc, &zRawAcc))
+  {
+    return WE_FAIL;
+  }
+  *xAcc = ISDS_convertAcceleration_int(xRawAcc, currentAccFullScale);
+  *yAcc = ISDS_convertAcceleration_int(yRawAcc, currentAccFullScale);
+  *zAcc = ISDS_convertAcceleration_int(zRawAcc, currentAccFullScale);
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the raw X-axis acceleration sensor output
+ * @param[out] xRawAcc The returned raw X-axis acceleration
+ * @retval Error code
+ */
+int8_t ISDS_getRawAccelerationX(int16_t *xRawAcc)
+{
+  uint8_t tmp[2] = {0};
+
+  if (WE_FAIL == ReadReg(ISDS_X_OUT_L_ACC_REG, 2, tmp))
+  {
+    return WE_FAIL;
+  }
+
+  *xRawAcc = (int16_t) (tmp[1] << 8);
+  *xRawAcc |= (int16_t) tmp[0];
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the raw Y-axis acceleration sensor output
+ * @param[out] yRawAcc The returned raw Y-axis acceleration
+ * @retval Error code
+ */
+int8_t ISDS_getRawAccelerationY(int16_t *yRawAcc)
+{
+  uint8_t tmp[2] = {0};
+
+  if (WE_FAIL == ReadReg(ISDS_Y_OUT_L_ACC_REG, 2, tmp))
+  {
+    return WE_FAIL;
+  }
+
+  *yRawAcc = (int16_t) (tmp[1] << 8);
+  *yRawAcc |= (int16_t) tmp[0];
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the raw Z-axis acceleration sensor output
+ * @param[out] zRawAcc The returned raw Z-axis acceleration
+ * @retval Error code
+ */
+int8_t ISDS_getRawAccelerationZ(int16_t *zRawAcc)
+{
+  uint8_t tmp[2] = {0};
+
+  if (WE_FAIL == ReadReg(ISDS_Z_OUT_L_ACC_REG, 2, tmp))
+  {
+    return WE_FAIL;
+  }
+
+  *zRawAcc = (int16_t) (tmp[1] << 8);
+  *zRawAcc |= (int16_t) tmp[0];
+
+  return WE_SUCCESS;
+}
+
+/**
+ * @brief Read the raw accelerometer sensor output for all three axes
+ * @param[out] xRawAcc The returned raw X-axis acceleration
+ * @param[out] yRawAcc The returned raw Y-axis acceleration
+ * @param[out] zRawAcc The returned raw Z-axis acceleration
+ * @retval Error code
+ */
+int8_t ISDS_getRawAccelerations(int16_t *xRawAcc, int16_t *yRawAcc, int16_t *zRawAcc)
+{
+  uint8_t tmp[6] = {0};
+
+  if (WE_FAIL == ReadReg(ISDS_X_OUT_L_ACC_REG, 6, tmp))
+  {
+    return WE_FAIL;
+  }
+
+  *xRawAcc = (int16_t) (tmp[1] << 8);
+  *xRawAcc |= (int16_t) tmp[0];
+
+  *yRawAcc = (int16_t) (tmp[3] << 8);
+  *yRawAcc |= (int16_t) tmp[2];
+
+  *zRawAcc = (int16_t) (tmp[5] << 8);
+  *zRawAcc |= (int16_t) tmp[4];
+
+  return WE_SUCCESS;
+}
+
+#ifdef WE_USE_FLOAT
+
+/**
+ * @brief Read the temperature in [°C]
+ * @param[out] temperature Temperature in [°C]
+ * @retval Error code
+ */
+int8_t ISDS_getTemperature_float(float *temperature)
+{
+  int16_t tempRaw;
+  if (WE_FAIL == ISDS_getRawTemperature(&tempRaw))
+  {
+    return WE_FAIL;
+  }
+  *temperature = ISDS_convertTemperature_float(tempRaw);
+  return WE_SUCCESS;
+}
+#endif /* WE_USE_FLOAT */
+/**
+ * @brief Read the temperature in [°C x 100]
+ * @param[out] temperature Temperature in [°C x 100]
+ * @retval Error code
+ */
+int8_t ISDS_getTemperature_int(int16_t *temperature)
+{
+  int16_t tempRaw;
+  if (WE_FAIL == ISDS_getRawTemperature(&tempRaw))
+  {
+    return WE_FAIL;
+  }
+  *temperature = ISDS_convertTemperature_int(tempRaw);
+  return WE_SUCCESS;
+}
+
+
+
+/**
+ * @brief Read the raw temperature
+ *
+ * Can be converted to [°C] using ISDS_convertTemperature_float()
+ *
+ * @param[out] temperature Raw temperature value (temperature sensor output)
+ * @retval Error code
+ */
+int8_t ISDS_getRawTemperature(int16_t *temperature)
+{
+  uint8_t tmp[2] = {0};
+
+  if (WE_FAIL == ReadReg(ISDS_OUT_TEMP_L_REG, 2, tmp))
+  {
+    return WE_FAIL;
+  }
+
+  *temperature = (int16_t) (tmp[1] << 8);
+  *temperature |= (int16_t) tmp[0];
+
+  return WE_SUCCESS;
+}
+
+
+#ifdef WE_USE_FLOAT
+/**
+ * @brief Converts the supplied raw acceleration into [mg]
+ * @param[in] acc Raw acceleration value (accelerometer output)
+ * @param[in] fullScale Accelerometer full scale
+ * @retval The converted acceleration in [mg]
+ */
+float ISDS_convertAcceleration_float(int16_t acc, ISDS_accFullScale_t fullScale)
+{
+  switch (fullScale)
+  {
+  case ISDS_accFullScaleTwoG:
+    return ISDS_convertAccelerationFs2g_float(acc);
+
+  case ISDS_accFullScaleSixteenG:
+    return ISDS_convertAccelerationFs16g_float(acc);
+
+  case ISDS_accFullScaleFourG:
+    return ISDS_convertAccelerationFs4g_float(acc);
+
+  case ISDS_accFullScaleEightG:
+    return ISDS_convertAccelerationFs8g_float(acc);
+
+  default:
+    return 0;
+  }
+}
+
+/**
+ * @brief Converts the supplied raw acceleration sampled using
+ * ISDS_accFullScaleTwoG to [mg]
+ * @param[in] acc Raw acceleration value (accelerometer output)
+ * @retval The converted acceleration in [mg]
+ */
+float ISDS_convertAccelerationFs2g_float(int16_t acc)
+{
+  return ((float) acc * 0.061f);
+}
+
+/**
+ * @brief Converts the supplied raw acceleration sampled using
+ * ISDS_accFullScaleFourG to [mg]
+ * @param[in] acc Raw acceleration value (accelerometer output)
+ * @retval The converted acceleration in [mg]
+ */
+float ISDS_convertAccelerationFs4g_float(int16_t acc)
+{
+  return ((float) acc * 0.122f);
+}
+
+/**
+ * @brief Converts the supplied raw acceleration sampled using
+ * ISDS_accFullScaleEightG to [mg]
+ * @param[in] acc Raw acceleration value (accelerometer output)
+ * @retval The converted acceleration in [mg]
+ */
+float ISDS_convertAccelerationFs8g_float(int16_t acc)
+{
+  return ((float) acc * 0.244f);
+}
+
+/**
+ * @brief Converts the supplied raw acceleration sampled using
+ * ISDS_accFullScaleSixteenG to [mg]
+ * @param[in] acc Raw acceleration value (accelerometer output)
+ * @retval The converted acceleration in [mg]
+ */
+float ISDS_convertAccelerationFs16g_float(int16_t acc)
+{
+  return ((float) acc * 0.488f);
+}
+
+/**
+ * @brief Converts the supplied raw angular rate into [mdps] (millidegrees per second).
+ * @param[in] rate Raw angular rate (gyroscope output)
+ * @param[in] fullScale Gyroscope full scale
+ * @retval The converted angular rate in [mdps] (millidegrees per second)
+ */
+float ISDS_convertAngularRate_float(int16_t rate, ISDS_gyroFullScale_t fullScale)
+{
+  switch (fullScale)
+  {
+  case ISDS_gyroFullScale250dps:
+    return ISDS_convertAngularRateFs250dps_float(rate);
+
+  case ISDS_gyroFullScale125dps:
+    return ISDS_convertAngularRateFs125dps_float(rate);
+
+  case ISDS_gyroFullScale500dps:
+    return ISDS_convertAngularRateFs500dps_float(rate);
+
+  case ISDS_gyroFullScale1000dps:
+    return ISDS_convertAngularRateFs1000dps_float(rate);
+
+  case ISDS_gyroFullScale2000dps:
+    return ISDS_convertAngularRateFs2000dps_float(rate);
+
+  default:
+    return 0;
+  }
+}
+
+/**
+ * @brief Converts the supplied raw angular rate sampled using
+ * ISDS_gyroFullScale125dps to [mdps] (millidegrees per second).
+ * @param[in] rate Raw angular rate (gyroscope output)
+ * @retval The converted angular rate in [mdps] (millidegrees per second)
+ */
+float ISDS_convertAngularRateFs125dps_float(int16_t rate)
+{
+  return ((float) rate * 4.375f);
+}
+
+/**
+ * @brief Converts the supplied raw angular rate sampled using
+ * ISDS_gyroFullScale250dps to [mdps] (millidegrees per second).
+ * @param[in] rate Raw angular rate (gyroscope output)
+ * @retval The converted angular rate in [mdps] (millidegrees per second)
+ */
+float ISDS_convertAngularRateFs250dps_float(int16_t rate)
+{
+  return ((float) rate * 8.75f);
+}
+
+/**
+ * @brief Converts the supplied raw angular rate sampled using
+ * ISDS_gyroFullScale500dps to [mdps] (millidegrees per second).
+ * @param[in] rate Raw angular rate (gyroscope output)
+ * @retval The converted angular rate in [mdps] (millidegrees per second)
+ */
+float ISDS_convertAngularRateFs500dps_float(int16_t rate)
+{
+  return ((float) rate * 17.5f);
+}
+
+/**
+ * @brief Converts the supplied raw angular rate sampled using
+ * ISDS_gyroFullScale1000dps to [mdps] (millidegrees per second).
+ * @param[in] rate Raw angular rate (gyroscope output)
+ * @retval The converted angular rate in [mdps] (millidegrees per second)
+ */
+float ISDS_convertAngularRateFs1000dps_float(int16_t rate)
+{
+  return ((float) rate * 35);
+}
+
+/**
+ * @brief Converts the supplied raw angular rate sampled using
+ * ISDS_gyroFullScale2000dps to [mdps] (millidegrees per second).
+ * @param[in] rate Raw angular rate (gyroscope output)
+ * @retval The converted angular rate in [mdps] (millidegrees per second)
+ */
+float ISDS_convertAngularRateFs2000dps_float(int16_t rate)
+{
+  return ((float) rate * 70);
+}
+
+/**
+ * @brief Converts the supplied raw temperature to [°C].
+ * @param[in] temperature Raw temperature (temperature sensor output)
+ * @retval The converted temperature in [°C]
+ */
+float ISDS_convertTemperature_float(int16_t temperature)
+{
+  return ((((float) temperature) / 256.0f) + 25.0f);
+}
+#endif /* WE_USE_FLOAT */
+
+
+/**
+ * @brief Converts the supplied raw acceleration into [mg]
+ * @param[in] acc Raw acceleration value (accelerometer output)
+ * @param[in] fullScale Accelerometer full scale
+ * @retval The converted acceleration in [mg]
+ */
+int16_t ISDS_convertAcceleration_int(int16_t acc, ISDS_accFullScale_t fullScale)
+{
+  switch (fullScale)
+  {
+  case ISDS_accFullScaleTwoG:
+    return ISDS_convertAccelerationFs2g_int(acc);
+
+  case ISDS_accFullScaleSixteenG:
+    return ISDS_convertAccelerationFs16g_int(acc);
+
+  case ISDS_accFullScaleFourG:
+    return ISDS_convertAccelerationFs4g_int(acc);
+
+  case ISDS_accFullScaleEightG:
+    return ISDS_convertAccelerationFs8g_int(acc);
+
+  default:
+    return 0;
+  }
+}
+
+/**
+ * @brief Converts the supplied raw acceleration sampled using
+ * ISDS_accFullScaleTwoG to [mg]
+ * @param[in] acc Raw acceleration value (accelerometer output)
+ * @retval The converted acceleration in [mg]
+ */
+int16_t ISDS_convertAccelerationFs2g_int(int16_t acc)
+{
+  return (int16_t) ((((int32_t) acc) * 61) / 1000);
+}
+
+/**
+ * @brief Converts the supplied raw acceleration sampled using
+ * ISDS_accFullScaleFourG to [mg]
+ * @param[in] acc Raw acceleration value (accelerometer output)
+ * @retval The converted acceleration in [mg]
+ */
+int16_t ISDS_convertAccelerationFs4g_int(int16_t acc)
+{
+  return (int16_t) ((((int32_t) acc) * 122) / 1000);
+}
+
+/**
+ * @brief Converts the supplied raw acceleration sampled using
+ * ISDS_accFullScaleEightG to [mg]
+ * @param[in] acc Raw acceleration value (accelerometer output)
+ * @retval The converted acceleration in [mg]
+ */
+int16_t ISDS_convertAccelerationFs8g_int(int16_t acc)
+{
+  return (int16_t) ((((int32_t) acc) * 244) / 1000);
+}
+
+/**
+ * @brief Converts the supplied raw acceleration sampled using
+ * ISDS_accFullScaleSixteenG to [mg]
+ * @param[in] acc Raw acceleration value (accelerometer output)
+ * @retval The converted acceleration in [mg]
+ */
+int16_t ISDS_convertAccelerationFs16g_int(int16_t acc)
+{
+  return (int16_t) ((((int32_t) acc) * 488) / 1000);
+}
+
+/**
+ * @brief Converts the supplied raw angular rate into [mdps] (millidegrees per second).
+ * @param[in] rate Raw angular rate (gyroscope output)
+ * @param[in] fullScale Gyroscope full scale
+ * @retval The converted angular rate in [mdps] (millidegrees per second)
+ */
+int32_t ISDS_convertAngularRate_int(int16_t rate, ISDS_gyroFullScale_t fullScale)
+{
+  switch (fullScale)
+  {
+  case ISDS_gyroFullScale250dps:
+    return ISDS_convertAngularRateFs250dps_int(rate);
+
+  case ISDS_gyroFullScale125dps:
+    return ISDS_convertAngularRateFs125dps_int(rate);
+
+  case ISDS_gyroFullScale500dps:
+    return ISDS_convertAngularRateFs500dps_int(rate);
+
+  case ISDS_gyroFullScale1000dps:
+    return ISDS_convertAngularRateFs1000dps_int(rate);
+
+  case ISDS_gyroFullScale2000dps:
+    return ISDS_convertAngularRateFs2000dps_int(rate);
+
+  default:
+    return 0;
+  }
+}
+
+/**
+ * @brief Converts the supplied raw angular rate sampled using
+ * ISDS_gyroFullScale125dps to [mdps] (millidegrees per second).
+ * @param[in] rate Raw angular rate (gyroscope output)
+ * @retval The converted angular rate in [mdps] (millidegrees per second)
+ */
+int32_t ISDS_convertAngularRateFs125dps_int(int16_t rate)
+{
+  return (((int32_t) rate) * 4375) / 1000;
+}
+
+/**
+ * @brief Converts the supplied raw angular rate sampled using
+ * ISDS_gyroFullScale250dps to [mdps] (millidegrees per second).
+ * @param[in] rate Raw angular rate (gyroscope output)
+ * @retval The converted angular rate in [mdps] (millidegrees per second)
+ */
+int32_t ISDS_convertAngularRateFs250dps_int(int16_t rate)
+{
+  return (((int32_t) rate) * 875) / 100;
+}
+
+/**
+ * @brief Converts the supplied raw angular rate sampled using
+ * ISDS_gyroFullScale500dps to [mdps] (millidegrees per second).
+ * @param[in] rate Raw angular rate (gyroscope output)
+ * @retval The converted angular rate in [mdps] (millidegrees per second)
+ */
+int32_t ISDS_convertAngularRateFs500dps_int(int16_t rate)
+{
+  return (((int32_t) rate) * 175) / 10;
+}
+
+/**
+ * @brief Converts the supplied raw angular rate sampled using
+ * ISDS_gyroFullScale1000dps to [mdps] (millidegrees per second).
+ * @param[in] rate Raw angular rate (gyroscope output)
+ * @retval The converted angular rate in [mdps] (millidegrees per second)
+ */
+int32_t ISDS_convertAngularRateFs1000dps_int(int16_t rate)
+{
+  return ((int32_t) rate) * 35;
+}
+
+/**
+ * @brief Converts the supplied raw angular rate sampled using
+ * ISDS_gyroFullScale2000dps to [mdps] (millidegrees per second).
+ * @param[in] rate Raw angular rate (gyroscope output)
+ * @retval The converted angular rate in [mdps] (millidegrees per second)
+ */
+int32_t ISDS_convertAngularRateFs2000dps_int(int16_t rate)
+{
+  return ((int32_t) rate) * 70;
+}
+
+/**
+ * @brief Converts the supplied raw temperature to [°C x 100].
+ * @param[in] temperature Raw temperature (temperature sensor output)
+ * @retval The converted temperature in [°C x 100]
+ */
+int16_t ISDS_convertTemperature_int(int16_t temperature)
+{
+  return (((int32_t) temperature) * 100) / 256 + 2500;
+}

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_WSEN_ISDS_2536030320001.h
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_WSEN_ISDS_2536030320001.h
@@ -1,0 +1,1340 @@
+/*
+ ***************************************************************************************************
+ * This file is part of Sensors SDK:
+ * https://www.we-online.com/sensors, https://github.com/WurthElektronik/Sensors-SDK_STM32
+ *
+ * THE SOFTWARE INCLUDING THE SOURCE CODE IS PROVIDED “AS IS”. YOU ACKNOWLEDGE THAT WÜRTH ELEKTRONIK
+ * EISOS MAKES NO REPRESENTATIONS AND WARRANTIES OF ANY KIND RELATED TO, BUT NOT LIMITED
+ * TO THE NON-INFRINGEMENT OF THIRD PARTIES’ INTELLECTUAL PROPERTY RIGHTS OR THE
+ * MERCHANTABILITY OR FITNESS FOR YOUR INTENDED PURPOSE OR USAGE. WÜRTH ELEKTRONIK EISOS DOES NOT
+ * WARRANT OR REPRESENT THAT ANY LICENSE, EITHER EXPRESS OR IMPLIED, IS GRANTED UNDER ANY PATENT
+ * RIGHT, COPYRIGHT, MASK WORK RIGHT, OR OTHER INTELLECTUAL PROPERTY RIGHT RELATING TO ANY
+ * COMBINATION, MACHINE, OR PROCESS IN WHICH THE PRODUCT IS USED. INFORMATION PUBLISHED BY
+ * WÜRTH ELEKTRONIK EISOS REGARDING THIRD-PARTY PRODUCTS OR SERVICES DOES NOT CONSTITUTE A LICENSE
+ * FROM WÜRTH ELEKTRONIK EISOS TO USE SUCH PRODUCTS OR SERVICES OR A WARRANTY OR ENDORSEMENT
+ * THEREOF
+ *
+ * THIS SOURCE CODE IS PROTECTED BY A LICENSE.
+ * FOR MORE INFORMATION PLEASE CAREFULLY READ THE LICENSE AGREEMENT FILE (license_terms_wsen_sdk.pdf)
+ * LOCATED IN THE ROOT DIRECTORY OF THIS DRIVER PACKAGE.
+ *
+ * COPYRIGHT (c) 2023 Würth Elektronik eiSos GmbH & Co. KG
+ *
+ ***************************************************************************************************
+ */
+
+/**
+ * @file
+ * @brief Header file for the WSEN-ISDS sensor driver.
+ */
+#ifndef FRI3DBADGE__WSEN_ISDS_H
+#define FRI3DBADGE__WSEN_ISDS_H
+
+#include <stdint.h>
+#include "Fri3dBadge_WSEN_ArduinoPlatform.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+/*         ISDS 2536030320001 DEVICE_ID         */
+
+#define ISDS_DEVICE_ID_VALUE                  0x6A      /**< This is the expected answer when requesting the ISDS_DEVICE_ID_REG */
+
+
+/*         Available ISDS I2C slave addresses         */
+
+#define ISDS_ADDRESS_I2C_0                    0x6A      /**< When SAO of ISDS is connected to ground */
+#define ISDS_ADDRESS_I2C_1                    0x6B      /**< When SAO of ISDS is connected to positive supply voltage */
+
+
+/* Register address definitions */
+
+#define ISDS_FIFO_CTRL_1_REG                  0x06      /**< FIFO configuration register 1 */
+#define ISDS_FIFO_CTRL_2_REG                  0x07      /**< FIFO configuration register 2 */
+#define ISDS_FIFO_CTRL_3_REG                  0x08      /**< FIFO configuration register 3 */
+#define ISDS_FIFO_CTRL_4_REG                  0x09      /**< FIFO configuration register 4 */
+#define ISDS_FIFO_CTRL_5_REG                  0x0A      /**< FIFO configuration register 5 */
+#define ISDS_DRDY_PULSE_CFG_REG               0x0B      /**< Data ready configuration register */
+#define ISDS_INT0_CTRL_REG                    0x0D      /**< INT0 pin control */
+#define ISDS_INT1_CTRL_REG                    0x0E      /**< INT1 pin control */
+#define ISDS_DEVICE_ID_REG                    0x0F      /**< Device ID register */
+#define ISDS_CTRL_1_REG                       0x10      /**< Control register 1 (linear acceleration sensor) */
+#define ISDS_CTRL_2_REG                       0x11      /**< Control register 2 (angular rate sensor) */
+#define ISDS_CTRL_3_REG                       0x12      /**< Control register 3 */
+#define ISDS_CTRL_4_REG                       0x13      /**< Control register 4 */
+#define ISDS_CTRL_5_REG                       0x14      /**< Control register 5 */
+#define ISDS_CTRL_6_REG                       0x15      /**< Control register 6 (angular rate sensor) */
+#define ISDS_CTRL_7_REG                       0x16      /**< Control register 7 (angular rate sensor) */
+#define ISDS_CTRL_8_REG                       0x17      /**< Control register 8 (linear acceleration sensor) */
+#define ISDS_CTRL_9_REG                       0x18      /**< Control register 9 (linear acceleration sensor) */
+#define ISDS_CTRL_10_REG                      0x19      /**< Control register 10 */
+#define ISDS_WAKE_UP_EVENT_REG                0x1B      /**< Wake-up interrupt source register */
+#define ISDS_TAP_EVENT_REG                    0x1C      /**< Tap source register */
+#define ISDS_6D_EVENT_REG                     0x1D      /**< 6D orientation source register */
+#define ISDS_STATUS_REG                       0x1E      /**< Status data register */
+#define ISDS_OUT_TEMP_L_REG                   0x20      /**< Temperature output value LSB */
+#define ISDS_OUT_TEMP_H_REG                   0x21      /**< Temperature output value MSB */
+#define ISDS_X_OUT_L_GYRO_REG                 0x22      /**< Angular rate output value X (pitch) LSB */
+#define ISDS_X_OUT_H_GYRO_REG                 0x23      /**< Angular rate output value X (pitch) MSB */
+#define ISDS_Y_OUT_L_GYRO_REG                 0x24      /**< Angular rate output value Y (roll) LSB */
+#define ISDS_Y_OUT_H_GYRO_REG                 0x25      /**< Angular rate output value Y (roll) MSB */
+#define ISDS_Z_OUT_L_GYRO_REG                 0x26      /**< Angular rate output value Z (yaw) LSB */
+#define ISDS_Z_OUT_H_GYRO_REG                 0x27      /**< Angular rate output value Z (yaw) MSB */
+#define ISDS_X_OUT_L_ACC_REG                  0x28      /**< Linear acceleration output value X LSB */
+#define ISDS_X_OUT_H_ACC_REG                  0x29      /**< Linear acceleration output value X MSB */
+#define ISDS_Y_OUT_L_ACC_REG                  0x2A      /**< Linear acceleration output value Y LSB */
+#define ISDS_Y_OUT_H_ACC_REG                  0x2B      /**< Linear acceleration output value Y MSB */
+#define ISDS_Z_OUT_L_ACC_REG                  0x2C      /**< Linear acceleration output value Z LSB */
+#define ISDS_Z_OUT_H_ACC_REG                  0x2D      /**< Linear acceleration output value Z MSB */
+#define ISDS_FIFO_STATUS_1_REG                0x3A      /**< FIFO status register 1 */
+#define ISDS_FIFO_STATUS_2_REG                0x3B      /**< FIFO status register 2 */
+#define ISDS_FIFO_STATUS_3_REG                0x3C      /**< FIFO status register 3 */
+#define ISDS_FIFO_STATUS_4_REG                0x3D      /**< FIFO status register 4 */
+#define ISDS_FIFO_DATA_OUT_L_REG              0x3E      /**< FIFO data output register LSB */
+#define ISDS_FIFO_DATA_OUT_H_REG              0x3F      /**< FIFO data output register MSB */
+#define ISDS_TIMESTAMP0_REG                   0x40      /**< Timestamp first byte (LSB) of 24-bit word */
+#define ISDS_TIMESTAMP1_REG                   0x41      /**< Timestamp second byte of 24-bit word */
+#define ISDS_TIMESTAMP2_REG                   0x42      /**< Timestamp third byte (MSB) of 24-bit word */
+#define ISDS_FUNC_SRC_1_REG                   0x53      /**< Tilt interrupt source register */
+#define ISDS_TAP_CFG_REG                      0x58      /**< Enables interrupt and inactivity functions, configuration of filtering and tap recognition functions */
+#define ISDS_TAP_THS_6D_REG                   0x59      /**< Portrait/landscape position and tap function threshold register */
+#define ISDS_INT_DUR2_REG                     0x5A      /**< Tap recognition function setting register */
+#define ISDS_WAKE_UP_THS_REG                  0x5B      /**< Single and double-tap function threshold register */
+#define ISDS_WAKE_UP_DUR_REG                  0x5C      /**< Free-fall, wake-up, timestamp and sleep mode functions duration setting register */
+#define ISDS_FREE_FALL_REG                    0x5D      /**< Free-fall function duration setting register */
+#define ISDS_MD1_CFG_REG                      0x5E      /**< Functions routing on INT0 register */
+#define ISDS_MD2_CFG_REG                      0x5F      /**< Functions routing on INT1 register */
+#define ISDS_X_OFS_USR_REG                    0x73      /**< Accelerometer X-axis user offset correction */
+#define ISDS_Y_OFS_USR_REG                    0x74      /**< Accelerometer Y-axis user offset correction */
+#define ISDS_Z_OFS_USR_REG                    0x75      /**< Accelerometer Z-axis user offset correction */
+
+
+/* Register type definitions */
+
+/**
+ * @brief ISDS_FIFO_CTRL_1_REG
+ *
+ * Address 0x06
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t fifoThresholdLsb : 8;         /**< FIFO threshold level setting LSB. Default value: 0. Watermark flag rises when the number of bytes written to FIFO after the next write is greater than or equal to the threshold level. Minimum resolution for the FIFO is 1 LSB = 2 bytes (1 word) in FIFO. */
+} ISDS_fifoCtrl1_t;
+
+/**
+ * @brief ISDS_FIFO_CTRL_2_REG
+ *
+ * Address 0x07
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t fifoThresholdMsb : 3;         /**< FIFO threshold level setting MSB. Default value: 0. Watermark flag rises when the number of bytes written to FIFO after the next write is greater than or equal to the threshold level. Minimum resolution for the FIFO is 1LSB = 2 bytes (1 word) in FIFO. */
+  uint8_t enFifoTemperature : 1;        /**< Enables the temperature data storage in FIFO. Default: 0. 0: temperature not included in FIFO; 1: temperature included in FIFO. */
+  uint8_t notUsed01 : 3;                /**< These bits must be set to 0 for proper operation of the device. */
+  uint8_t enFifoTimestamp : 1;          /**< Enables timestamp data to be stored as the 4th FIFO data set. 0: timestamp not included in FIFO; 1: timestamp included in FIFO. */
+} ISDS_fifoCtrl2_t;
+
+/**
+ * @brief ISDS_FIFO_CTRL_3_REG
+ *
+ * Address 0x08
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t fifoAccDecimation : 3;        /**< Accelerometer FIFO (second data set) decimation setting. Default: 0. See ISDS_fifoDecimation_t. */
+  uint8_t fifoGyroDecimation : 3;       /**< Gyro FIFO (first data set) decimation setting. Default: 0. See ISDS_fifoDecimation_t. */
+  uint8_t notUsed01 : 2;                /**< These bits must be set to 0 for proper operation of the device. */
+} ISDS_fifoCtrl3_t;
+
+/**
+ * @brief ISDS_FIFO_CTRL_4_REG
+ *
+ * Address 0x09
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t fifoThirdDecimation : 3;      /**< Third FIFO data set decimation setting. Default: 0. See ISDS_fifoDecimation_t. */
+  uint8_t fifoFourthDecimation : 3;     /**< Fourth FIFO data set decimation setting. Default: 0. See ISDS_fifoDecimation_t. */
+  uint8_t enOnlyHighData : 1;           /**< 8-bit data storage in FIFO. Default: 0. 0: disable MSB only memorization in FIFO for XL and Gyro; 1: enable MSB only memorization in FIFO for XL and Gyro in FIFO. */
+  uint8_t enStopOnThreshold : 1;        /**< Enable FIFO threshold level use. Default value: 0. 0: FIFO depth is not limited; 1: FIFO depth is limited to threshold level. */
+} ISDS_fifoCtrl4_t;
+
+/**
+ * @brief ISDS_FIFO_CTRL_5_REG
+ *
+ * Address 0x0A
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t fifoMode : 3;                 /**< FIFO mode. See ISDS_fifoMode_t. */
+  uint8_t fifoOdr : 4;                  /**< FIFO output data rate. See ISDS_fifoOutputDataRate_t. */
+  uint8_t notUsed01 : 1;                /**< This bit must be set to 0 for proper operation of the device. */
+} ISDS_fifoCtrl5_t;
+
+/**
+ * @brief ISDS_DRDY_PULSE_CFG_REG
+ *
+ * Address 0x0B
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t notUsed01 : 7;                /**< These bits must be set to 0 for proper operation of the device. */
+  uint8_t enDataReadyPulsed : 1;        /**< Enable pulsed data-ready mode. Default value: 0. 0: data-ready latched mode. Returns to 0 only after output data has been read; 1: data-ready pulsed mode. The data-ready pulses are 75 μs long. */
+} ISDS_dataReadyPulseCfg_t;
+
+/**
+ * @brief ISDS_INT0_CTRL_REG
+ *
+ * Address 0x0D
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t int0AccDataReady : 1;         /**< Accelerometer data-ready on INT0 pin. Default value: 0. */
+  uint8_t int0GyroDataReady : 1;        /**< Gyroscope data-ready on INT0 pin. Default value: 0. */
+  uint8_t int0Boot : 1;                 /**< Boot status on INT0 pin. Default value: 0. */
+  uint8_t int0FifoThreshold : 1;        /**< FIFO threshold interrupt on INT0 pin. Default value: 0. */
+  uint8_t int0FifoOverrun : 1;          /**< FIFO overrun interrupt on INT0 pin. Default value: 0. */
+  uint8_t int0FifoFull : 1;             /**< FIFO full interrupt on INT0 pin. Default value: 0. */
+  uint8_t notUsed01 : 2;                /**< These bits must be set to 0 for proper operation of the device. */
+} ISDS_int0Ctrl_t;
+
+/**
+ * @brief ISDS_INT1_CTRL_REG
+ *
+ * Address 0x0E
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t int1AccDataReady : 1;         /**< Accelerometer data-ready on INT1 pin. Default value: 0. */
+  uint8_t int1GyroDataReady : 1;        /**< Gyroscope data-ready on INT1 pin. Default value: 0. */
+  uint8_t int1TempDataReady : 1;        /**< Temperature data-ready on INT1 pin. Default value: 0. */
+  uint8_t int1FifoThreshold : 1;        /**< FIFO threshold interrupt on INT1 pin. Default value: 0. */
+  uint8_t int1FifoOverrun : 1;          /**< FIFO overrun interrupt on INT1 pin. Default value: 0. */
+  uint8_t int1FifoFull : 1;             /**< FIFO full interrupt on INT1 pin. Default value: 0. */
+  uint8_t notUsed01 : 2;                /**< These bits must be set to 0 for proper operation of the device. */
+} ISDS_int1Ctrl_t;
+
+/**
+ * @brief ISDS_CTRL_1_REG
+ *
+ * Address 0x10
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t accAnalogBandwidth : 1;       /**< Accelerometer analog chain bandwidth selection (only for accelerometer ODR ≥ 1.67 kHz). See ISDS_accAnalogChainBandwidth_t. */
+  uint8_t accDigitalBandwidth : 1;      /**< Accelerometer digital LPF (LPF1) bandwidth selection. See ISDS_accDigitalLpfBandwidth_t. */
+  uint8_t accFullScale : 2;             /**< Accelerometer full-scale selection. Default value: 0. See ISDS_accFullScale_t. */
+  uint8_t accOutputDataRate : 4;        /**< Output data rate and power mode selection. Default value: 0. See ISDS_accOutputDataRate_t. */
+} ISDS_ctrl1_t;
+
+/**
+ * @brief ISDS_CTRL_2_REG
+ *
+ * Address 0x11
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t notUsed01 : 1;                /**< This bit must be set to 0 for proper operation of the device. */
+  uint8_t gyroFullScale : 3;            /**< Gyroscope full-scale selection. Default value: 0. See ISDS_gyroFullScale_t. */
+  uint8_t gyroOutputDataRate : 4;       /**< Output data rate and power mode selection. Default value: 0. See ISDS_gyroOutputDataRate_t. */
+} ISDS_ctrl2_t;
+
+/**
+ * @brief ISDS_CTRL_3_REG
+ *
+ * Address 0x12
+ * Type  R/W
+ * Default value: 0x04
+ */
+typedef struct
+{
+  uint8_t softReset : 1;                /**< Software reset. 0: normal mode; 1: SW reset; Self-clearing upon completion. */
+  uint8_t notUsed01 : 1;                /**< This bit must be set to 0 for proper operation of the device. */
+  uint8_t autoAddIncr : 1;              /**< Register address automatically incremented during a multiple byte access with I2C/SPI interface. Default: 1. 0: disable; 1: enable. */
+  uint8_t spiMode : 1;                  /**< SPI serial interface mode. 0: 4-wire interface; 1: 3-wire interface. See ISDS_spiMode_t.*/
+  uint8_t intPinConf : 1;               /**< Push-pull/open-drain selection on INT0 and INT1 pads. Default value: 0. 0: push-pull mode; 1: open-drain mode. See ISDS_interruptPinConfig_t. */
+  uint8_t intActiveLevel : 1;           /**< Interrupt activation level. Default value: 0. 0: interrupt output pads active high; 1: interrupt output pads active low. See ISDS_interruptActiveLevel_t. */
+  uint8_t blockDataUpdate : 1;          /**< Block data update. 0: continuous update; 1: output registers are not updated until MSB and LSB have been read. */
+  uint8_t boot : 1;                     /**< Set this bit to 1 to initiate boot sequence. 0: normal mode; 1: Execute boot sequence. Self-clearing upon completion. */
+} ISDS_ctrl3_t;
+
+/**
+ * @brief ISDS_CTRL_4_REG
+ *
+ * Address 0x13
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t notUsed01 : 1;                  /**< This bit must be set to 0 for proper operation of the device. */
+  uint8_t enGyroLPF1 : 1;                 /**< Enable gyroscope digital LPF1. 0: disabled; 1: enabled. */
+  uint8_t i2cDisable : 1;                 /**< Disable I2C interface. Default value: 0. 0: both I2C and SPI enabled; 1: I2C disabled, SPI only. */
+  uint8_t dataReadyMask : 1;              /**< Enables masking of the accelerometer and gyroscope data-ready signals until the settling of the sensor filters is completed. Default value: 0. 0: Masking disabled; 1: Masking enabled. */
+  uint8_t dataEnableDataReadyOnInt0 : 1;  /**< Data enable (DEN) data ready signal on INT0 pad. Default value: 0. 0: disabled; 1: enabled. */
+  uint8_t int1OnInt0 : 1;                 /**< All interrupt signals available on INT0 pad enable. Default value: 0. 0: interrupt signals divided between INT0 and INT1 pads; 1: all interrupt signals in logic or on INT0 pad. */
+  uint8_t enGyroSleepMode : 1;            /**< Gyroscope sleep mode enable. Default value: 0. 0: disabled; 1: enabled. */
+  uint8_t dataEnableExtendToAcc : 1;      /**< Extend data enable (DEN) functionality to accelerometer sensor. Default value: 0. 0: disabled; 1: enabled. */
+} ISDS_ctrl4_t;
+
+/**
+ * @brief ISDS_CTRL_5_REG
+ *
+ * Address 0x14
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t accSelfTest : 2;              /**< Accelerometer self-test enable. Default value: 0. See ISDS_accSelfTestMode_t. */
+  uint8_t gyroSelfTest : 2;             /**< Gyroscope self-test enable. Default value: 0. See ISDS_gyroSelfTestMode_t. */
+  uint8_t dataEnableActiveLevel : 1;    /**< Data enable (DEN) active level configuration. Default value: 0. 0: active low; 1: active high. */
+  uint8_t rounding : 3;                 /**< Circular burst-mode (rounding) read from output registers through the primary interface. Default value: 0. See ISDS_roundingPattern_t. */
+} ISDS_ctrl5_t;
+
+/**
+ * @brief ISDS_CTRL_6_REG
+ *
+ * Address 0x15
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t gyroLowPassFilterType : 2;            /**< Gyroscope low-pass filter (LPF1) bandwidth selection. See ISDS_gyroLPF_t. */
+  uint8_t notUsed01 : 1;                        /**< This bit must be set to 0 for proper operation of the device. */
+  uint8_t userOffsetsWeight : 1;                /**< Weight of accelerometer user offset bits in registers ISDS_X_OFS_USR_REG, ISDS_Y_OFS_USR_REG, ISDS_Z_OFS_USR_REG. 0: 2^-10 g/LSB; 1: 2^-6 g/LSB. */
+  uint8_t accHighPerformanceModeDisable : 1;    /**< High-performance operating mode disable for accelerometer. Default value: 0. 0: high-performance operating mode enabled; 1: high-performance operating mode disabled. */
+  uint8_t dataEnableTriggerMode : 3;            /**< Data enable (DEN) trigger mode. See ISDS_dataEnableTriggerMode_t. */
+} ISDS_ctrl6_t;
+
+/**
+ * @brief ISDS_CTRL_7_REG
+ *
+ * Address 0x16
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t notUsed01 : 2;                        /**< These bits must be set to 0 for proper operation of the device. */
+  uint8_t enRounding : 1;                       /**< Source register rounding function on ISDS_WAKE_UP_EVENT_REG, ISDS_TAP_EVENT_REG, ISDS_6D_EVENT_REG, ISDS_STATUS_REG and ISDS_FUNC_SRC_1_REG registers in the primary interface. Default value: 0. 0: rounding disabled; 1: rounding enabled. */
+  uint8_t notUsed02 : 1;                        /**< This bit must be set to 0 for proper operation of the device. */
+  uint8_t gyroDigitalHighPassCutoff : 2;        /**< Gyroscope digital HP filter cutoff selection. Default: 0. See ISDS_gyroDigitalHighPassCutoff_t. */
+  uint8_t gyroDigitalHighPassEnable : 1;        /**< Gyroscope digital high-pass filter enable. The filter is enabled only if the gyro is in HP mode. Default value: 0. 0: HPF disabled; 1: HPF enabled. */
+  uint8_t gyroHighPerformanceModeDisable : 1;   /**< High-performance operating mode disable for gyroscope. Default: 0. 0: high-performance operating mode enabled; 1: high-performance operating mode disabled. */
+} ISDS_ctrl7_t;
+
+/**
+ * @brief ISDS_CTRL_8_REG
+ *
+ * Address 0x17
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t en6dLowPass: 1;                 /**< LPF2 on 6D function selection. */
+  uint8_t notUsed01 : 1;                  /**< This bit must be set to 0 for proper operation of the device. */
+  uint8_t enAccHighPassSlopeFilter : 1;   /**< Accelerometer slope filter / high-pass filter selection. 0: the low-pass path of the composite filter block is selected; 1: the high-pass path of the composite filter block is selected. */
+  uint8_t inputComposite : 1;             /**< Composite filter input selection. See ISDS_inputCompositeFilter_t. Default: 0. 0: ODR/2 low pass filtered sent to composite filter (default); 1: ODR/4 low pass filtered sent to composite filter. */
+  uint8_t highPassFilterRefMode : 1;      /**< Enable HP filter reference mode (when enabled, the first output data has to be discarded). Default value: 0. 0: disabled; 1: enabled. */
+  uint8_t accFilterConfig : 2;            /**< Accelerometer LPF2 and high-pass filter configuration and cutoff setting. See ISDS_accFilterConfig_t. */
+  uint8_t enAccLowPass : 1;               /**< Accelerometer low-pass filter LPF2 selection. */
+} ISDS_ctrl8_t;
+
+/**
+ * @brief ISDS_CTRL_9_REG
+ *
+ * Address 0x18
+ * Type  R/W
+ * Default value: 0xE0
+ */
+typedef struct
+{
+  uint8_t notUsed01 : 4;                  /**< These bits must be set to 0 for proper operation of the device. */
+  uint8_t dataEnableStampingSensor : 1;   /**< Data enable (DEN) stamping sensor selection. See ISDS_dataEnableStampingSensor_t. Default value: 0. 0: DEN pin info stamped in the gyroscope axis selected by bits [7:5]; 1: DEN pin info stamped in the accelerometer axis selected by bits [7:5]. */
+  uint8_t dataEnableValueZ : 1;           /**< Data enable (DEN) value stored in LSB of Z-axis. Default value: 1. 0: DEN not stored in Z-axis LSB; 1: DEN stored in Z-axis LSB. */
+  uint8_t dataEnableValueY : 1;           /**< Data enable (DEN) value stored in LSB of Y-axis. Default value: 1. 0: DEN not stored in Y-axis LSB; 1: DEN stored in Y-axis LSB. */
+  uint8_t dataEnableValueX : 1;           /**< Data enable (DEN) value stored in LSB of X-axis. Default value: 1. 0: DEN not stored in X-axis LSB; 1: DEN stored in X-axis LSB. */
+} ISDS_ctrl9_t;
+
+/**
+ * @brief ISDS_CTRL_10_REG
+ *
+ * Address 0x19
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t notUsed01 : 2;                  /**< These bits must be set to 0 for proper operation of the device. */
+  uint8_t enEmbeddedFunc : 1;             /**< Enable embedded functionalities (tilt). Default value: 0. 0: disable functionalities of embedded functions and accelerometer filters; 1: enable functionalities of embedded functions and accelerometer filters. */
+  uint8_t enTiltCalculation : 1;          /**< Enable tilt calculation. */
+  uint8_t notUsed02 : 1;                  /**< This bit must be set to 0 for proper operation of the device. */
+  uint8_t enTimestampCount : 1;           /**< Enable timestamp count. The count is saved in ISDS_TIMESTAMP0_REG, ISDS_TIMESTAMP1_REG and ISDS_TIMESTAMP2_REG. Default: 0. 0: timestamp count disabled; 1: timestamp count enabled. */
+  uint8_t notUsed03 : 2;                  /**< These bits must be set to 0 for proper operation of the device. */
+} ISDS_ctrl10_t;
+
+/**
+ * @brief ISDS_WAKE_UP_EVENT_REG
+ *
+ * Address 0x1B
+ * Type  R
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t wakeUpZ : 1;                    /**< Wake-up event on Z-axis status. 0: Wake-up event on Z-axis not detected; 1: Wake-up event on Z-axis detected. */
+  uint8_t wakeUpY : 1;                    /**< Wake-up event on Y-axis status. 0: Wake-up event on Y-axis not detected; 1: Wake-up event on Y-axis detected. */
+  uint8_t wakeUpX : 1;                    /**< Wake-up event on X-axis status. 0: Wake-up event on X-axis not detected; 1: Wake-up event on X-axis detected. */
+  uint8_t wakeUpState : 1;                /**< Wake-up event detection status. 0: Wake-up event not detected; 1: Wake-up event detected. */
+  uint8_t sleepState : 1;                 /**< Sleep event status. 0: Sleep event not detected; 1: Sleep event detected. */
+  uint8_t freeFallState : 1;              /**< Free-fall event detection status. 0: FF event not detected; 1: FF event detected. */
+  uint8_t notUsed01 : 2;                  /**< These bits must be set to 0 for proper operation of the device. */
+} ISDS_wakeUpEvent_t;
+
+/**
+ * @brief ISDS_TAP_EVENT_REG
+ *
+ * Address 0x1C
+ * Type  R
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t tapZAxis : 1;                   /**< Tap event detection on Z-axis status. 0: Tap event on Z-axis not detected; 1: Tap event on Z-axis detected. */
+  uint8_t tapYAxis : 1;                   /**< Tap event detection on Y-axis status. 0: Tap event on Y-axis not detected; 1: Tap event on Y-axis detected. */
+  uint8_t tapXAxis : 1;                   /**< Tap event detection on X-axis status. 0: Tap event on X-axis not detected; 1: Tap event on X-axis detected. */
+  uint8_t tapSign : 1;                    /**< Sign of acceleration detected by tap event. 0: Tap in positive direction; 1: Tap in negative direction. */
+  uint8_t doubleState : 1;                /**< Double-tap event status. 0: Double-tap event not detected; 1: Double-tap event detected. */
+  uint8_t singleState : 1;                /**< Single-tap event status. 0: Single-tap event not detected; 1: Single-tap event detected. */
+  uint8_t tapEventState : 1;              /**< Tap event status. 0: Tap event not detected; 1: Tap event detected. */
+  uint8_t notUsed01 : 1;                  /**< This bit must be set to 0 for proper operation of the device. */
+} ISDS_tapEvent_t;
+
+/**
+ * @brief ISDS_6D_EVENT_REG
+ *
+ * Address 0x1D
+ * Type  R
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t xlOverThreshold : 1;            /**< 1: XL threshold exceeded; 0: XL threshold not exceeded */
+  uint8_t xhOverThreshold : 1;            /**< 1: XH threshold exceeded; 0: XH threshold not exceeded */
+  uint8_t ylOverThreshold : 1;            /**< 1: YL threshold exceeded; 0: YL threshold not exceeded */
+  uint8_t yhOverThreshold : 1;            /**< 1: YH threshold exceeded; 0: YH threshold not exceeded */
+  uint8_t zlOverThreshold : 1;            /**< 1: ZL threshold exceeded; 0: ZL threshold not exceeded */
+  uint8_t zhOverThreshold : 1;            /**< 1: ZH threshold exceeded; 0: ZH threshold not exceeded */
+  uint8_t sixDChange : 1;                 /**< Orientation change detection status (0: No event detected; 1: A change in orientation has been detected) */
+  uint8_t dataEnableDataReady : 1;        /**< Data enable (DEN) data-ready signal. It is set high when data output is related to the data coming from a DEN active condition. */
+} ISDS_6dEvent_t;
+
+/**
+ * @brief ISDS_STATUS_REG
+ *
+ * Address 0x1E
+ * Type  R
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t accDataReady : 1;               /**< 1: New acceleration data available; 0: No new data available. */
+  uint8_t gyroDataReady : 1;              /**< 1: New gyroscope data available; 0: No new data available. */
+  uint8_t tempDataReady: 1;               /**< 1: New temperature data available; 0: No new data available. */
+  uint8_t notUsed01 : 5;                  /**< These bits must be set to 0 for proper operation of the device. */
+} ISDS_status_t;
+
+/**
+ * @brief ISDS_FIFO_STATUS_1_REG
+ *
+ * Address 0x3A
+ * Type  R
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t fifoFillLevelLsb : 8;           /**< Current fill level of FIFO (0-2047) i.e. the number of unread samples (16-bit values). */
+} ISDS_fifoStatus1_t;
+
+/**
+ * @brief ISDS_FIFO_STATUS_2_REG
+ *
+ * Address 0x3B
+ * Type  R
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t fifoFillLevelMsb : 3;           /**< Current fill level of FIFO (0-2047) i.e. the number of unread samples (16-bit values). */
+  uint8_t notUsed01 : 1;                  /**< This bit must be set to 0 for proper operation of the device. */
+  uint8_t fifoEmptyState : 1;             /**< FIFO empty bit. Default value: 0. 0: FIFO contains data; 1: FIFO is empty. */
+  uint8_t fifoFullSmartState : 1;         /**< Smart FIFO full status. Default value: 0. 0: FIFO is not full; 1: FIFO will be full at the next ODR. */
+  uint8_t fifoOverrunState : 1;           /**< FIFO overrun status. Default value: 0. 0: FIFO is not completely filled; 1: FIFO is completely filled. */
+  uint8_t fifoThresholdState : 1;         /**< FIFO threshold status bit. 0: FIFO filling is lower than threshold level, 1: FIFO filling is equal to or higher than the threshold level. */
+} ISDS_fifoStatus2_t;
+
+/**
+ * @brief ISDS_FIFO_STATUS_3_REG
+ *
+ * Address 0x3C
+ * Type  R
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t fifoPatternLsb : 8;       /**< Word of recursive pattern read at the next read. */
+} ISDS_fifoStatus3_t;
+
+/**
+ * @brief ISDS_FIFO_STATUS_4_REG
+ *
+ * Address 0x3D
+ * Type  R
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t fifoPatternMsb : 2;       /**< Word of recursive pattern read at the next read. */
+  uint8_t notUsed01 : 6;            /**< These bits must be set to 0 for proper operation of the device. */
+} ISDS_fifoStatus4_t;
+
+/**
+ * @brief ISDS_FUNC_SRC_1_REG
+ *
+ * Address 0x53
+ * Type  R
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t notUsed01 : 5;            /**< These bits must be set to 0 for proper operation of the device. */
+  uint8_t tiltState : 1;            /**< Tilt event detection status. Default value: 0. 0: tilt event not detected; 1: tilt event detected. */
+  uint8_t notUsed02 : 2;            /**< These bits must be set to 0 for proper operation of the device. */
+} ISDS_funcSrc1_t;
+
+/**
+ * @brief ISDS_TAP_CFG_REG
+ *
+ * Address 0x58
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t latchedInterrupt : 1;     /**< Latched Interrupt. Default value: 0. 0: interrupt request not latched; 1: interrupt request latched. */
+  uint8_t enTapZ : 1;               /**< Enable Z direction in tap recognition. Default value: 0. 0: Z direction disabled; 1: Z direction enabled. */
+  uint8_t enTapY : 1;               /**< Enable Y direction in tap recognition. Default value: 0. 0: Y direction disabled; 1: Y direction enabled. */
+  uint8_t enTapX : 1;               /**< Enable X direction in tap recognition. Default value: 0. 0: X direction disabled; 1: X direction enabled. */
+  uint8_t filterSelection : 1;      /**< HPF or SLOPE filter selection on wake-up and activity/inactivity functions. See ISDS_activityFilter_t. Default value: 0. 0: SLOPE filter applied; 1: HPF applied. */
+  uint8_t enInactivity : 2;         /**< Enable inactivity function. Default value: 0. See ISDS_inactivityFunction_t. */
+  uint8_t enInterrupts : 1;         /**< Enable basic interrupts (6D/4D, free-fall, wake-up, tap, inactivity). Default value: 0. 0: interrupt disabled; 1: interrupt enabled. */
+} ISDS_tapCfg_t;
+
+/**
+ * @brief ISDS_TAP_THS_6D_REG
+ *
+ * Address 0x59
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t tapThreshold : 5;           /**< Threshold for tap recognition. Default value: 0. 1 LSB corresponds to FS/32. */
+  uint8_t sixDThreshold : 2;          /**< Threshold for 4D/6D function. Default value: 0. See ISDS_sixDThreshold_t. */
+  uint8_t fourDDetectionEnabled : 1;  /**< Enable 4D portrait/landscape detection. 0: 4D mode disabled; 1: portrait/landscape detection and face-up/face-down detection enabled. */
+} ISDS_tapThs6d_t;
+
+/**
+ * @brief ISDS_INT_DUR2_REG
+ *
+ * Address 0x5A
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t shock : 2;                /**< Defines the maximum duration of over-threshold event when detecting taps. */
+  uint8_t quiet : 2;                /**< Defines the expected quiet time after a tap detection. */
+  uint8_t latency : 4;              /**< Defines the maximum duration time gap for double-tap recognition. */
+} ISDS_intDur2_t;
+
+/**
+ * @brief ISDS_WAKE_UP_THS_REG
+ *
+ * Address 0x5B
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t wakeUpThreshold : 6;      /**< Defines wake-up threshold, 6-bit unsigned 1 LSB = 1/64 of FS. Default value: 0. */
+  uint8_t notUsed01 : 1;            /**< This bit must be set to 0 for proper operation of the device. */
+  uint8_t enDoubleTapEvent : 1;     /**< Enable double-tap event. Default value: 0. 0: enable only single-tap; 1: enable both (single and double-tap). */
+} ISDS_wakeUpThs_t;
+
+/**
+ * @brief ISDS_WAKE_UP_DUR_REG
+ *
+ * Address 0x5C
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t sleepDuration : 4;        /**< Defines the sleep mode duration. Default value is 0 (which is 16 * 1/ODR). 1 LSB = 512 * 1/ODR */
+  uint8_t timestampResolution : 1;  /**< Timestamp register resolution setting. See ISDS_timestampResolution_t. Default value: 0. 0: 1LSB = 6.4 ms; 1: 1LSB = 25 μs. */
+  uint8_t wakeUpDuration : 2;       /**< This parameter defines the wake-up duration. 1 LSB = 1 * 1/ODR. */
+  uint8_t freeFallDurationMSB : 1;  /**< This bit defines the free-fall duration. Combined with FF_DUR [4:0] bit in ISDS_FREE_FALL_REG register. 1 LSB = 1 * 1/ODR. */
+} ISDS_wakeUpDur_t;
+
+/**
+ * @brief ISDS_FREE_FALL_REG
+ *
+ * Address 0x5D
+ * Type  R/W
+ * Default value: 0x00
+ *
+ *  freeFallThreshold  |  Decoded threshold
+ * ----------------------------------------
+ *         000         |        5
+ *         001         |        7
+ *         010         |        8
+ *         011         |        10
+ *         100         |        11
+ *         101         |        13
+ *         110         |        15
+ *         111         |        16
+ */
+typedef struct
+{
+  uint8_t freeFallThreshold : 3;    /**< Encoded free-fall threshold value. See ISDS_freeFallThreshold_t. The decoded value can be multiplied with 31.25mg to get the used threshold. */
+  uint8_t freeFallDurationLSB: 5;   /**< Defines free-fall duration. Is combined with FF_DUR5 bit in ISDS_WAKE_UP_DUR_REG register. 1 LSB = 1 * 1/ODR. */
+} ISDS_freeFall_t;
+
+/**
+ * @brief ISDS_MD1_CFG_REG
+ *
+ * Address 0x5E
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t int0Timer : 1;            /**< Routing of end counter event of timer on INT0. Default value: 0. 0: routing disabled; 1: routing enabled. */
+  uint8_t int0Tilt : 1;             /**< Routing of tilt event on INT0. Default value: 0. 0: routing disabled; 1: routing enabled. */
+  uint8_t int06d : 1;               /**< Routing of 6D event on INT0. Default value: 0. 0: routing disabled; 1: routing enabled. */
+  uint8_t int0DoubleTap : 1;        /**< Routing of double tap event on INT0. Default value: 0. 0: routing disabled; 1: routing enabled. */
+  uint8_t int0FreeFall : 1;         /**< Routing of free fall event on INT0. Default value: 0. 0: routing disabled; 1: routing enabled. */
+  uint8_t int0WakeUp : 1;           /**< Routing of wake-up event on INT0. Default value: 0. 0: routing disabled; 1: routing enabled. */
+  uint8_t int0SingleTap : 1;        /**< Routing of single tap event on INT0. Default value: 0. 0: routing disabled; 1: routing enabled. */
+  uint8_t int0InactivityState : 1;  /**< Routing of inactivity on INT0. Default value: 0. 0: routing disabled; 1: routing enabled. */
+} ISDS_mde1Cfg_t;
+
+/**
+ * @brief ISDS_MD2_CFG_REG
+ *
+ * Address 0x5F
+ * Type  R/W
+ * Default value: 0x00
+ */
+typedef struct
+{
+  uint8_t notUsed01 : 1;            /**< This bit must be set to 0 for proper operation of the device. */
+  uint8_t int1Tilt : 1;             /**< Routing of tilt event on INT1. Default value: 0. 0: routing disabled; 1: routing enabled. */
+  uint8_t int16d : 1;               /**< Routing of 6D event on INT1. Default value: 0. 0: routing disabled; 1: routing enabled. */
+  uint8_t int1DoubleTap : 1;        /**< Routing of double tap event on INT1. Default value: 0. 0: routing disabled; 1: routing enabled. */
+  uint8_t int1FreeFall : 1;         /**< Routing of free fall event on INT1. Default value: 0. 0: routing disabled; 1: routing enabled. */
+  uint8_t int1WakeUp : 1;           /**< Routing of wake-up event on INT1. Default value: 0. 0: routing disabled; 1: routing enabled. */
+  uint8_t int1SingleTap : 1;        /**< Routing of single tap event on INT1. Default value: 0. 0: routing disabled; 1: routing enabled. */
+  uint8_t int1InactivityState : 1;  /**< Routing of inactivity on INT1. Default value: 0. 0: routing disabled; 1: routing enabled. */
+} ISDS_mde2Cfg_t;
+
+
+/*         Functional type definitions         */
+
+typedef enum
+{
+  ISDS_disable = 0,
+  ISDS_enable = 1
+} ISDS_state_t;
+
+typedef enum
+{
+  ISDS_positive = 0,
+  ISDS_negative = 1
+} ISDS_tapSign_t;
+
+typedef enum
+{
+  ISDS_fifoDecimationNoFifo   = 0,
+  ISDS_fifoDecimationDisabled = 1,
+  ISDS_fifoDecimationFactor2  = 2,
+  ISDS_fifoDecimationFactor3  = 3,
+  ISDS_fifoDecimationFactor4  = 4,
+  ISDS_fifoDecimationFactor8  = 5,
+  ISDS_fifoDecimationFactor16 = 6,
+  ISDS_fifoDecimationFactor32 = 7
+} ISDS_fifoDecimation_t;
+
+typedef enum
+{
+  ISDS_bypassMode = 0,
+  ISDS_fifoEnabled = 1,
+  ISDS_continuousToFifo = 3,
+  ISDS_bypassToContinuous = 4,
+  ISDS_continuousMode = 6
+} ISDS_fifoMode_t;
+
+typedef enum
+{
+  ISDS_fifoOdrOff    =  0,
+  ISDS_fifoOdr12Hz5  =  1,
+  ISDS_fifoOdr26Hz   =  2,
+  ISDS_fifoOdr52Hz   =  3,
+  ISDS_fifoOdr104Hz  =  4,
+  ISDS_fifoOdr208Hz  =  5,
+  ISDS_fifoOdr416Hz  =  6,
+  ISDS_fifoOdr833Hz  =  7,
+  ISDS_fifoOdr1k66Hz =  8,
+  ISDS_fifoOdr3k33Hz =  9,
+  ISDS_fifoOdr6k66Hz = 10
+} ISDS_fifoOutputDataRate_t;
+
+typedef enum
+{
+  ISDS_accAnalogChainBandwidth1k5Hz = 0,    /**< 1.5 kHz */
+  ISDS_accAnalogChainBandwidth400Hz = 1     /**< 400 Hz */
+} ISDS_accAnalogChainBandwidth_t;
+
+typedef enum
+{
+  ISDS_accDigitalLpfBandwidthOdrDiv2 = 0,   /**< ODR / 2 */
+  ISDS_accDigitalLpfBandwidthOdrDiv4 = 1    /**< ODR / 4 */
+} ISDS_accDigitalLpfBandwidth_t;
+
+typedef enum
+{
+  ISDS_inputCompositeFilterOdrDiv2 = 0,     /**< ODR / 2 */
+  ISDS_inputCompositeFilterOdrDiv4 = 1      /**< ODR / 4 */
+} ISDS_inputCompositeFilter_t;
+
+typedef enum
+{
+  ISDS_accFullScaleTwoG       = 0,
+  ISDS_accFullScaleSixteenG   = 1,
+  ISDS_accFullScaleFourG      = 2,
+  ISDS_accFullScaleEightG     = 3,
+  ISDS_accFullScaleInvalid    = 4
+} ISDS_accFullScale_t;
+
+typedef enum
+{
+  ISDS_accOdrOff      =  0,
+  ISDS_accOdr12Hz5    =  1,
+  ISDS_accOdr26Hz     =  2,
+  ISDS_accOdr52Hz     =  3,
+  ISDS_accOdr104Hz    =  4,
+  ISDS_accOdr208Hz    =  5,
+  ISDS_accOdr416Hz    =  6,
+  ISDS_accOdr833Hz    =  7,
+  ISDS_accOdr1k66Hz   =  8,
+  ISDS_accOdr3k33Hz   =  9,
+  ISDS_accOdr6k66Hz   = 10,
+  ISDS_accOdr1Hz6     = 11
+} ISDS_accOutputDataRate_t;
+
+typedef enum
+{
+  ISDS_gyroFullScale250dps   = 0,
+  ISDS_gyroFullScale125dps   = 1,
+  ISDS_gyroFullScale500dps   = 2,
+  ISDS_gyroFullScale1000dps  = 4,
+  ISDS_gyroFullScale2000dps  = 6
+} ISDS_gyroFullScale_t;
+
+typedef enum
+{
+  ISDS_gyroOdrOff    =  0,
+  ISDS_gyroOdr12Hz5  =  1,
+  ISDS_gyroOdr26Hz   =  2,
+  ISDS_gyroOdr52Hz   =  3,
+  ISDS_gyroOdr104Hz  =  4,
+  ISDS_gyroOdr208Hz  =  5,
+  ISDS_gyroOdr416Hz  =  6,
+  ISDS_gyroOdr833Hz  =  7,
+  ISDS_gyroOdr1k66Hz =  8,
+  ISDS_gyroOdr3k33Hz =  9,
+  ISDS_gyroOdr6k66Hz = 10
+} ISDS_gyroOutputDataRate_t;
+
+typedef enum
+{
+  ISDS_spiModeFourWire  = 0,
+  ISDS_spiModeThreeWire = 1
+} ISDS_spiMode_t;
+
+typedef enum
+{
+  ISDS_pushPull  = 0,
+  ISDS_openDrain = 1
+} ISDS_interruptPinConfig_t;
+
+typedef enum
+{
+  ISDS_activeHigh = 0,
+  ISDS_activeLow  = 1
+} ISDS_interruptActiveLevel_t;
+
+typedef enum
+{
+  ISDS_accSelfTestModeOff      = 0,
+  ISDS_accSelfTestModePositive = 1,
+  ISDS_accSelfTestModeNegative = 2
+} ISDS_accSelfTestMode_t;
+
+typedef enum
+{
+  ISDS_gyroSelfTestModeOff      = 0,
+  ISDS_gyroSelfTestModePositive = 1,
+  ISDS_gyroSelfTestModeNegative = 3
+} ISDS_gyroSelfTestMode_t;
+
+typedef enum
+{
+  ISDS_roundingPatternNoRounding                  = 0,   /**< No rounding */
+  ISDS_roundingPatternAccOnly                     = 1,   /**< Accelerometer only */
+  ISDS_roundingPatternGyroOnly                    = 2,   /**< Gyroscope only */
+  ISDS_roundingPatternGyroAndAcc                  = 3    /**< Gyroscope and accelerometer */
+} ISDS_roundingPattern_t;
+
+typedef enum
+{
+  ISDS_dataEnableTriggerModeDisabled               = 0,
+  ISDS_dataEnableTriggerModeEdgeSensitiveTrigger   = 4,
+  ISDS_dataEnableTriggerModeLevelSensitiveTrigger  = 2,
+  ISDS_dataEnableTriggerModeLevelSensitiveLatched  = 3,
+  ISDS_dataEnableTriggerModeLevelSensitiveFifo     = 6
+} ISDS_dataEnableTriggerMode_t;
+
+typedef enum
+{
+  ISDS_gyroLPF_ODR800Hz_BW245Hz_PhaseDelay14Deg = 0,
+  ISDS_gyroLPF_ODR800Hz_BW195Hz_PhaseDelay17Deg = 1,
+  ISDS_gyroLPF_ODR800Hz_BW155Hz_PhaseDelay19Deg = 2,
+  ISDS_gyroLPF_ODR800Hz_BW293Hz_PhaseDelay13Deg = 3,
+  ISDS_gyroLPF_ODR1k6Hz_BW315Hz_PhaseDelay10Deg = 0,
+  ISDS_gyroLPF_ODR1k6Hz_BW224Hz_PhaseDelay12Deg = 1,
+  ISDS_gyroLPF_ODR1k6Hz_BW168Hz_PhaseDelay15Deg = 2,
+  ISDS_gyroLPF_ODR1k6Hz_BW505Hz_PhaseDelay8Deg  = 3,
+  ISDS_gyroLPF_ODR3k3Hz_BW343Hz_PhaseDelay8Deg  = 0,
+  ISDS_gyroLPF_ODR3k3Hz_BW234Hz_PhaseDelay10Deg = 1,
+  ISDS_gyroLPF_ODR3k3Hz_BW172Hz_PhaseDelay12Deg = 2,
+  ISDS_gyroLPF_ODR3k3Hz_BW925Hz_PhaseDelay6Deg  = 3,
+  ISDS_gyroLPF_ODR6k6Hz_BW351Hz_PhaseDelay7Deg  = 0,
+  ISDS_gyroLPF_ODR6k6Hz_BW237Hz_PhaseDelay9Deg  = 1,
+  ISDS_gyroLPF_ODR6k6Hz_BW173Hz_PhaseDelay11Deg = 2,
+  ISDS_gyroLPF_ODR6k6Hz_BW937Hz_PhaseDelay5Deg  = 3
+} ISDS_gyroLPF_t;
+
+typedef enum
+{
+  ISDS_gyroDigitalHighPassCutoff16mHz  = 0,
+  ISDS_gyroDigitalHighPassCutoff65mHz  = 1,
+  ISDS_gyroDigitalHighPassCutoff260mHz = 2,
+  ISDS_gyroDigitalHighPassCutoff1Hz04  = 3
+} ISDS_gyroDigitalHighPassCutoff_t;
+
+typedef enum
+{
+  ISDS_accFilterConfig_LowPassPath_ODRDiv50   = 0,
+  ISDS_accFilterConfig_LowPassPath_ODRDiv100  = 1,
+  ISDS_accFilterConfig_LowPassPath_ODRDiv9    = 2,
+  ISDS_accFilterConfig_LowPassPath_ODRDiv400  = 3,
+  ISDS_accFilterConfig_HighPassPath_ODRDiv4   = 0,
+  ISDS_accFilterConfig_HighPassPath_ODRDiv100 = 1,
+  ISDS_accFilterConfig_HighPassPath_ODRDiv9   = 2,
+  ISDS_accFilterConfig_HighPassPath_ODRDiv400 = 3
+} ISDS_accFilterConfig_t;
+
+typedef enum
+{
+  ISDS_dataEnableStampingSensorGyro = 0,
+  ISDS_dataEnableStampingSensorAcc  = 1
+} ISDS_dataEnableStampingSensor_t;
+
+typedef enum
+{
+  ISDS_activityFilterSlope    = 0,
+  ISDS_activityFilterHighPass = 1
+} ISDS_activityFilter_t;
+
+typedef enum
+{
+  ISDS_timestampResolution6ms4 = 0,
+  ISDS_timestampResolution25mus  = 1
+} ISDS_timestampResolution_t;
+
+typedef enum
+{
+  ISDS_inactivityFunctionDisabled              = 0,
+  ISDS_inactivityFunctionAcc12Hz5GyroUnchanged = 1,
+  ISDS_inactivityFunctionAcc12Hz5GyroSleep     = 2,
+  ISDS_inactivityFunctionAcc12Hz5GyroPowerDown = 3
+} ISDS_inactivityFunction_t;
+
+typedef enum
+{
+  ISDS_sixDThresholdEightyDeg   = 0,
+  ISDS_sixDThresholdSeventyDeg  = 1,
+  ISDS_sixDThresholdSixtyDeg    = 2,
+  ISDS_sixDThresholdFiftyDeg    = 3
+} ISDS_sixDThreshold_t;
+
+typedef enum
+{
+  ISDS_freeFallThreshold156mg = 0,
+  ISDS_freeFallThreshold219mg = 1,
+  ISDS_freeFallThreshold250mg = 2,
+  ISDS_freeFallThreshold312mg = 3,
+  ISDS_freeFallThreshold344mg = 4,
+  ISDS_freeFallThreshold406mg = 5,
+  ISDS_freeFallThreshold469mg = 6,
+  ISDS_freeFallThreshold500mg = 7
+} ISDS_freeFallThreshold_t;
+
+
+  /*         Function definitions         */
+
+  int8_t ISDS_getDeviceID(uint8_t *deviceID);
+
+  /* ISDS_FIFO_CTRL_1_REG */
+  /* ISDS_FIFO_CTRL_2_REG */
+  int8_t ISDS_setFifoThreshold(uint16_t threshold);
+  int8_t ISDS_getFifoThreshold(uint16_t *threshold);
+  int8_t ISDS_enableFifoTemperature(ISDS_state_t fifoTemp);
+  int8_t ISDS_isFifoTemperatureEnabled(ISDS_state_t *fifoTemp);
+  int8_t ISDS_enableFifoTimestamp(ISDS_state_t fifoTimestamp);
+  int8_t ISDS_isFifoTimestampEnabled(ISDS_state_t *fifoTimestamp);
+
+  /* ISDS_FIFO_CTRL_3_REG */
+  int8_t ISDS_setFifoAccDecimation(ISDS_fifoDecimation_t decimation);
+  int8_t ISDS_getFifoAccDecimation(ISDS_fifoDecimation_t *decimation);
+  int8_t ISDS_setFifoGyroDecimation(ISDS_fifoDecimation_t decimation);
+  int8_t ISDS_getFifoGyroDecimation(ISDS_fifoDecimation_t *decimation);
+
+  /* ISDS_FIFO_CTRL_4_REG */
+  int8_t ISDS_setFifoDataset3Decimation(ISDS_fifoDecimation_t decimation);
+  int8_t ISDS_getFifoDataset3Decimation(ISDS_fifoDecimation_t *decimation);
+  int8_t ISDS_setFifoDataset4Decimation(ISDS_fifoDecimation_t decimation);
+  int8_t ISDS_getFifoDataset4Decimation(ISDS_fifoDecimation_t *decimation);
+  int8_t ISDS_enableFifoOnlyHighData(ISDS_state_t onlyHighData);
+  int8_t ISDS_isFifoOnlyHighDataEnabled(ISDS_state_t *onlyHighData);
+  int8_t ISDS_enableFifoStopOnThreshold(ISDS_state_t stopOnThreshold);
+  int8_t ISDS_isFifoStopOnThresholdEnabled(ISDS_state_t *stopOnThreshold);
+
+  /* ISDS_FIFO_CTRL_5_REG */
+  int8_t ISDS_setFifoMode(ISDS_fifoMode_t fifoMode);
+  int8_t ISDS_getFifoMode(ISDS_fifoMode_t *fifoMode);
+  int8_t ISDS_setFifoOutputDataRate(ISDS_fifoOutputDataRate_t fifoOdr);
+  int8_t ISDS_getFifoOutputDataRate(ISDS_fifoOutputDataRate_t *fifoOdr);
+
+  /* ISDS_DRDY_PULSE_CFG_REG */
+  int8_t ISDS_enableDataReadyPulsed(ISDS_state_t dataReadyPulsed);
+  int8_t ISDS_isDataReadyPulsedEnabled(ISDS_state_t *dataReadyPulsed);
+
+  /* ISDS_INT0_CTRL_REG */
+  int8_t ISDS_enableAccDataReadyINT0(ISDS_state_t int0AccDataReady);
+  int8_t ISDS_isAccDataReadyINT0Enabled(ISDS_state_t *int0AccDataReady);
+  int8_t ISDS_enableGyroDataReadyINT0(ISDS_state_t int0GyroDataReady);
+  int8_t ISDS_isGyroDataReadyINT0Enabled(ISDS_state_t *int0GyroDataReady);
+  int8_t ISDS_enableBootStatusINT0(ISDS_state_t int0BootStatus);
+  int8_t ISDS_isBootStatusINT0Enabled(ISDS_state_t *int0BootStatus);
+  int8_t ISDS_enableFifoThresholdINT0(ISDS_state_t int0FifoThreshold);
+  int8_t ISDS_isFifoThresholdINT0Enabled(ISDS_state_t *int0FifoThreshold);
+  int8_t ISDS_enableFifoOverrunINT0(ISDS_state_t int0FifoOverrun);
+  int8_t ISDS_isFifoOverrunINT0Enabled(ISDS_state_t *int0FifoOverrun);
+  int8_t ISDS_enableFifoFullINT0(ISDS_state_t int0FifoFull);
+  int8_t ISDS_isFifoFullINT0Enabled(ISDS_state_t *int0FifoFull);
+
+  /* ISDS_INT1_CTRL_REG */
+  int8_t ISDS_enableAccDataReadyINT1(ISDS_state_t int1AccDataReady);
+  int8_t ISDS_isAccDataReadyINT1Enabled(ISDS_state_t *int1AccDataReady);
+  int8_t ISDS_enableGyroDataReadyINT1(ISDS_state_t int1GyroDataReady);
+  int8_t ISDS_isGyroDataReadyINT1Enabled(ISDS_state_t *int1GyroDataReady);
+  int8_t ISDS_enableTemperatureDataReadyINT1(ISDS_state_t int1TempDataReady);
+  int8_t ISDS_isTemperatureDataReadyINT1Enabled(ISDS_state_t *int1TempDataReady);
+  int8_t ISDS_enableFifoThresholdINT1(ISDS_state_t int1FifoThreshold);
+  int8_t ISDS_isFifoThresholdINT1Enabled(ISDS_state_t *int1FifoThreshold);
+  int8_t ISDS_enableFifoOverrunINT1(ISDS_state_t int1FifoOverrun);
+  int8_t ISDS_isFifoOverrunINT1Enabled(ISDS_state_t *int1FifoOverrun);
+  int8_t ISDS_enableFifoFullINT1(ISDS_state_t int1FifoFull);
+  int8_t ISDS_isFifoFullINT1Enabled(ISDS_state_t *int1FifoFull);
+
+  /* ISDS_DEVICE_ID_REG */
+
+  /* ISDS_CTRL_1_REG */
+  int8_t ISDS_setAccAnalogChainBandwidth(ISDS_accAnalogChainBandwidth_t bandwidth);
+  int8_t ISDS_getAccAnalogChainBandwidth(ISDS_accAnalogChainBandwidth_t *bandwidth);
+  int8_t ISDS_setAccDigitalLpfBandwidth(ISDS_accDigitalLpfBandwidth_t bandwidth);
+  int8_t ISDS_getAccDigitalLpfBandwidth(ISDS_accDigitalLpfBandwidth_t *bandwidth);
+  int8_t ISDS_setAccFullScale(ISDS_accFullScale_t fullScale);
+  int8_t ISDS_getAccFullScale(ISDS_accFullScale_t *fullScale);
+  int8_t ISDS_setAccOutputDataRate(ISDS_accOutputDataRate_t odr);
+  int8_t ISDS_getAccOutputDataRate(ISDS_accOutputDataRate_t *odr);
+
+  /* ISDS_CTRL_2_REG */
+  int8_t ISDS_setGyroFullScale(ISDS_gyroFullScale_t fullScale);
+  int8_t ISDS_getGyroFullScale(ISDS_gyroFullScale_t *fullScale);
+  int8_t ISDS_setGyroOutputDataRate(ISDS_gyroOutputDataRate_t odr);
+  int8_t ISDS_getGyroOutputDataRate(ISDS_gyroOutputDataRate_t *odr);
+
+  /* ISDS_CTRL_3_REG */
+  int8_t ISDS_softReset(ISDS_state_t swReset);
+  int8_t ISDS_getSoftResetState(ISDS_state_t *swReset);
+  int8_t ISDS_enableAutoIncrement(ISDS_state_t autoIncr);
+  int8_t ISDS_isAutoIncrementEnabled(ISDS_state_t *autoIncr);
+  int8_t ISDS_setSpiMode(ISDS_spiMode_t spiMode);
+  int8_t ISDS_getSpiMode(ISDS_spiMode_t *spiMode);
+  int8_t ISDS_setInterruptPinType(ISDS_interruptPinConfig_t pinType);
+  int8_t ISDS_getInterruptPinType(ISDS_interruptPinConfig_t *pinType);
+  int8_t ISDS_setInterruptActiveLevel(ISDS_interruptActiveLevel_t level);
+  int8_t ISDS_getInterruptActiveLevel(ISDS_interruptActiveLevel_t *level);
+  int8_t ISDS_enableBlockDataUpdate(ISDS_state_t bdu);
+  int8_t ISDS_isBlockDataUpdateEnabled(ISDS_state_t *bdu);
+  int8_t ISDS_reboot(ISDS_state_t reboot);
+  int8_t ISDS_isRebooting(ISDS_state_t *rebooting);
+
+  /* ISDS_CTRL_4_REG */
+  int8_t ISDS_enableGyroDigitalLpf1(ISDS_state_t enable);
+  int8_t ISDS_isGyroDigitalLpf1Enabled(ISDS_state_t *enable);
+  int8_t ISDS_disableI2CInterface(ISDS_state_t i2cDisable);
+  int8_t ISDS_isI2CInterfaceDisabled(ISDS_state_t *i2cDisabled);
+  int8_t ISDS_enableDataReadyMask(ISDS_state_t dataReadyMask);
+  int8_t ISDS_isDataReadyMaskEnabled(ISDS_state_t *dataReadyMask);
+  int8_t ISDS_enableDataEnableDataReadyINT0(ISDS_state_t int0DataReady);
+  int8_t ISDS_isDataEnableDataReadyINT0Enabled(ISDS_state_t *int0DataReady);
+  int8_t ISDS_setInt1OnInt0(ISDS_state_t int1OnInt0);
+  int8_t ISDS_getInt1OnInt0(ISDS_state_t *int1OnInt0);
+  int8_t ISDS_enableGyroSleepMode(ISDS_state_t gyroSleepMode);
+  int8_t ISDS_isGyroSleepModeEnabled(ISDS_state_t *gyroSleepMode);
+  int8_t ISDS_extendDataEnableToAcc(ISDS_state_t extendToAcc);
+  int8_t ISDS_isDataEnableExtendedToAcc(ISDS_state_t *extendToAcc);
+
+  /* ISDS_CTRL_5_REG */
+  int8_t ISDS_setAccSelfTestMode(ISDS_accSelfTestMode_t selfTest);
+  int8_t ISDS_getAccSelfTestMode(ISDS_accSelfTestMode_t *selfTest);
+  int8_t ISDS_setGyroSelfTestMode(ISDS_gyroSelfTestMode_t selfTest);
+  int8_t ISDS_getGyroSelfTestMode(ISDS_gyroSelfTestMode_t *selfTest);
+  int8_t ISDS_setDataEnableActiveHigh(ISDS_state_t activeHigh);
+  int8_t ISDS_isDataEnableActiveHigh(ISDS_state_t *activeHigh);
+  int8_t ISDS_setRoundingPattern(ISDS_roundingPattern_t roundingPattern);
+  int8_t ISDS_getRoundingPattern(ISDS_roundingPattern_t *roundingPattern);
+
+  /* ISDS_CTRL_6_REG */
+  int8_t ISDS_setGyroLowPassFilterBandwidth(ISDS_gyroLPF_t bandwidth);
+  int8_t ISDS_getGyroLowPassFilterBandwidth(ISDS_gyroLPF_t *bandwidth);
+  int8_t ISDS_setOffsetWeight(ISDS_state_t offsetWeight);
+  int8_t ISDS_getOffsetWeight(ISDS_state_t *offsetWeight);
+  int8_t ISDS_disableAccHighPerformanceMode(ISDS_state_t disable);
+  int8_t ISDS_isAccHighPerformanceModeDisabled(ISDS_state_t *disable);
+  int8_t ISDS_setDataEnableTriggerMode(ISDS_dataEnableTriggerMode_t triggerMode);
+  int8_t ISDS_getDataEnableTriggerMode(ISDS_dataEnableTriggerMode_t *triggerMode);
+
+  /* ISDS_CTRL_7_REG */
+  int8_t ISDS_enableRounding(ISDS_state_t rounding);
+  int8_t ISDS_isRoundingEnabled(ISDS_state_t *rounding);
+  int8_t ISDS_setGyroDigitalHighPassCutoff(ISDS_gyroDigitalHighPassCutoff_t cutoff);
+  int8_t ISDS_getGyroDigitalHighPassCutoff(ISDS_gyroDigitalHighPassCutoff_t *cutoff);
+  int8_t ISDS_enableGyroDigitalHighPass(ISDS_state_t highPass);
+  int8_t ISDS_isGyroDigitalHighPassEnabled(ISDS_state_t *highPass);
+  int8_t ISDS_disableGyroHighPerformanceMode(ISDS_state_t disable);
+  int8_t ISDS_isGyroHighPerformanceModeDisabled(ISDS_state_t *disable);
+
+  /* ISDS_CTRL_8_REG */
+  int8_t ISDS_enable6dLowPass(ISDS_state_t lowPass);
+  int8_t ISDS_is6dLowPassEnabled(ISDS_state_t *lowPass);
+  int8_t ISDS_enableAccHighPassSlopeFilter(ISDS_state_t filterEnable);
+  int8_t ISDS_isAccHighPassSlopeFilterEnabled(ISDS_state_t *filterEnable);
+  int8_t ISDS_setInputCompositeFilter(ISDS_inputCompositeFilter_t inputCompositeFilter);
+  int8_t ISDS_getInputCompositeFilter(ISDS_inputCompositeFilter_t *inputCompositeFilter);
+  int8_t ISDS_enableHighPassFilterRefMode(ISDS_state_t refMode);
+  int8_t ISDS_isHighPassFilterRefModeEnabled(ISDS_state_t *refMode);
+  int8_t ISDS_setAccFilterConfig(ISDS_accFilterConfig_t filterConfig);
+  int8_t ISDS_getAccFilterConfig(ISDS_accFilterConfig_t *filterConfig);
+  int8_t ISDS_enableAccLowPass(ISDS_state_t lowPass);
+  int8_t ISDS_isAccLowPassEnabled(ISDS_state_t *lowPass);
+
+  /* ISDS_CTRL_9_REG */
+  int8_t ISDS_setDataEnableStampingSensor(ISDS_dataEnableStampingSensor_t sensor);
+  int8_t ISDS_getDataEnableStampingSensor(ISDS_dataEnableStampingSensor_t *sensor);
+  int8_t ISDS_storeDataEnableValueInZAxisLSB(ISDS_state_t enable);
+  int8_t ISDS_isStoreDataEnableValueInZAxisLSB(ISDS_state_t *enable);
+  int8_t ISDS_storeDataEnableValueInYAxisLSB(ISDS_state_t enable);
+  int8_t ISDS_isStoreDataEnableValueInYAxisLSB(ISDS_state_t *enable);
+  int8_t ISDS_storeDataEnableValueInXAxisLSB(ISDS_state_t enable);
+  int8_t ISDS_isStoreDataEnableValueInXAxisLSB(ISDS_state_t *enable);
+
+  /* ISDS_CTRL_10_REG */
+  int8_t ISDS_enableEmbeddedFunctionalities(ISDS_state_t embeddedFuncEnable);
+  int8_t ISDS_areEmbeddedFunctionalitiesEnabled(ISDS_state_t *embeddedFuncEnable);
+  int8_t ISDS_enableTiltCalculation(ISDS_state_t tiltCalc);
+  int8_t ISDS_isTiltCalculationEnabled(ISDS_state_t *tiltCalc);
+  int8_t ISDS_enableTimestampCount(ISDS_state_t timestampCount);
+  int8_t ISDS_isTimestampCountEnabled(ISDS_state_t *timestampCount);
+
+  /* ISDS_WAKE_UP_EVENT_REG */
+  int8_t ISDS_getWakeUpEventRegister(ISDS_wakeUpEvent_t *status);
+  int8_t ISDS_isWakeUpXEvent(ISDS_state_t *wakeUpX);
+  int8_t ISDS_isWakeUpYEvent(ISDS_state_t *wakeUpY);
+  int8_t ISDS_isWakeUpZEvent(ISDS_state_t *wakeUpZ);
+  int8_t ISDS_isWakeUpEvent(ISDS_state_t *wakeUpState);
+  int8_t ISDS_getSleepState(ISDS_state_t *sleepState);
+  int8_t ISDS_isFreeFallEvent(ISDS_state_t *freeFall);
+
+  /* ISDS_TAP_EVENT_REG */
+  int8_t ISDS_getTapEventRegister(ISDS_tapEvent_t *status);
+  int8_t ISDS_isTapEvent(ISDS_state_t *tapEventState);
+  int8_t ISDS_isTapEventXAxis(ISDS_state_t *tapXAxis);
+  int8_t ISDS_isTapEventYAxis(ISDS_state_t *tapYAxis);
+  int8_t ISDS_isTapEventZAxis(ISDS_state_t *tapZAxis);
+  int8_t ISDS_isDoubleTapEvent(ISDS_state_t *doubleTap);
+  int8_t ISDS_isSingleTapEvent(ISDS_state_t *singleTap);
+  int8_t ISDS_getTapSign(ISDS_tapSign_t *tapSign);
+
+  /* ISDS_6D_EVENT_REG */
+  int8_t ISDS_get6dEventRegister(ISDS_6dEvent_t *status);
+  int8_t ISDS_has6dOrientationChanged(ISDS_state_t *orientationChanged);
+  int8_t ISDS_isXLOverThreshold(ISDS_state_t *xlOverThreshold);
+  int8_t ISDS_isXHOverThreshold(ISDS_state_t *xhOverThreshold);
+  int8_t ISDS_isYLOverThreshold(ISDS_state_t *ylOverThreshold);
+  int8_t ISDS_isYHOverThreshold(ISDS_state_t *yhOverThreshold);
+  int8_t ISDS_isZLOverThreshold(ISDS_state_t *zlOverThreshold);
+  int8_t ISDS_isZHOverThreshold(ISDS_state_t *zhOverThreshold);
+  int8_t ISDS_isDataEnableDataReady(ISDS_state_t *dataReady);
+
+  /* ISDS_STATUS_REG */
+  int8_t ISDS_getStatusRegister(ISDS_status_t *status);
+  int8_t ISDS_isAccelerationDataReady(ISDS_state_t *dataReady);
+  int8_t ISDS_isGyroscopeDataReady(ISDS_state_t *dataReady);
+  int8_t ISDS_isTemperatureDataReady(ISDS_state_t *dataReady);
+
+  /* ISDS_FIFO_STATUS_#_REG */
+  int8_t ISDS_getFifoStatus(ISDS_fifoStatus2_t *status, uint16_t *fillLevel, uint16_t *fifoPattern);
+  int8_t ISDS_getFifoStatus2Register(ISDS_fifoStatus2_t *status);
+  int8_t ISDS_getFifoFillLevel(uint16_t *fillLevel);
+  int8_t ISDS_isFifoEmpty(ISDS_state_t *empty);
+  int8_t ISDS_isFifoFull(ISDS_state_t *full);
+  int8_t ISDS_getFifoOverrunState(ISDS_state_t *overrun);
+  int8_t ISDS_isFifoThresholdReached(ISDS_state_t *threshReached);
+  int8_t ISDS_getFifoPattern(uint16_t *fifoPattern);
+
+  /* ISDS_FUNC_SRC_1_REG */
+  int8_t ISDS_isTiltEvent(ISDS_state_t *tiltEvent);
+
+  /* ISDS_TAP_CFG_REG */
+  int8_t ISDS_enableLatchedInterrupt(ISDS_state_t lir);
+  int8_t ISDS_isLatchedInterruptEnabled(ISDS_state_t *lir);
+  int8_t ISDS_enableTapX(ISDS_state_t tapX);
+  int8_t ISDS_isTapXEnabled(ISDS_state_t *tapX);
+  int8_t ISDS_enableTapY(ISDS_state_t tapY);
+  int8_t ISDS_isTapYEnabled(ISDS_state_t *tapY);
+  int8_t ISDS_enableTapZ(ISDS_state_t tapZ);
+  int8_t ISDS_isTapZEnabled(ISDS_state_t *tapZ);
+  int8_t ISDS_setActivityFilter(ISDS_activityFilter_t filter);
+  int8_t ISDS_getActivityFilter(ISDS_activityFilter_t *filter);
+  int8_t ISDS_setInactivityFunction(ISDS_inactivityFunction_t function);
+  int8_t ISDS_getInactivityFunction(ISDS_inactivityFunction_t *function);
+  int8_t ISDS_enableInterrupts(ISDS_state_t interruptsEnable);
+  int8_t ISDS_areInterruptsEnabled(ISDS_state_t *interruptsEnable);
+
+  /* ISDS_TAP_THS_6D_REG */
+  int8_t ISDS_setTapThreshold(uint8_t tapThreshold);
+  int8_t ISDS_getTapThreshold(uint8_t *tapThreshold);
+  int8_t ISDS_set6DThreshold(ISDS_sixDThreshold_t threshold6D);
+  int8_t ISDS_get6DThreshold(ISDS_sixDThreshold_t *threshold6D);
+  int8_t ISDS_enable4DDetection(ISDS_state_t detection4D);
+  int8_t ISDS_is4DDetectionEnabled(ISDS_state_t *detection4D);
+
+  /* ISDS_INT_DUR2_REG */
+  int8_t ISDS_setTapLatencyTime(uint8_t latencyTime);
+  int8_t ISDS_getTapLatencyTime(uint8_t *latencyTime);
+  int8_t ISDS_setTapQuietTime(uint8_t quietTime);
+  int8_t ISDS_getTapQuietTime(uint8_t *quietTime);
+  int8_t ISDS_setTapShockTime(uint8_t shockTime);
+  int8_t ISDS_getTapShockTime(uint8_t *shockTime);
+
+  /* ISDS_WAKE_UP_THS_REG */
+  int8_t ISDS_setWakeUpThreshold(uint8_t thresh);
+  int8_t ISDS_getWakeUpThreshold(uint8_t *thresh);
+  int8_t ISDS_enableDoubleTapEvent(ISDS_state_t doubleTapEnable);
+  int8_t ISDS_isDoubleTapEventEnabled(ISDS_state_t *doubleTapEnable);
+
+  /* ISDS_WAKE_UP_DUR_REG */
+  int8_t ISDS_setSleepDuration(uint8_t duration);
+  int8_t ISDS_getSleepDuration(uint8_t *duration);
+  int8_t ISDS_setTimestampResolution(ISDS_timestampResolution_t resolution);
+  int8_t ISDS_getTimestampResolution(ISDS_timestampResolution_t *resolution);
+  int8_t ISDS_setWakeUpDuration(uint8_t duration);
+  int8_t ISDS_getWakeUpDuration(uint8_t *duration);
+
+  /* ISDS_FREE_FALL_REG */
+  int8_t ISDS_setFreeFallThreshold(ISDS_freeFallThreshold_t thresh);
+  int8_t ISDS_getFreeFallThreshold(ISDS_freeFallThreshold_t *thresh);
+  int8_t ISDS_setFreeFallDuration(uint8_t duration);
+  int8_t ISDS_getFreeFallDuration(uint8_t *duration);
+
+  /* ISDS_MD1_CFG_REG */
+  int8_t ISDS_enableTimerEndCounterINT0(ISDS_state_t int0Timer);
+  int8_t ISDS_isTimerEndCounterINT0Enabled(ISDS_state_t *int0Timer);
+  int8_t ISDS_enableTiltINT0(ISDS_state_t int0Tilt);
+  int8_t ISDS_isTiltINT0Enabled(ISDS_state_t *int0Tilt);
+  int8_t ISDS_enable6dINT0(ISDS_state_t int06d);
+  int8_t ISDS_is6dINT0Enabled(ISDS_state_t *int06d);
+  int8_t ISDS_enableDoubleTapINT0(ISDS_state_t int0DoubleTap);
+  int8_t ISDS_isDoubleTapINT0Enabled(ISDS_state_t *int0DoubleTap);
+  int8_t ISDS_enableFreeFallINT0(ISDS_state_t int0FreeFall);
+  int8_t ISDS_isFreeFallINT0Enabled(ISDS_state_t *int0FreeFall);
+  int8_t ISDS_enableWakeUpINT0(ISDS_state_t int0WakeUp);
+  int8_t ISDS_isWakeUpINT0Enabled(ISDS_state_t *int0WakeUp);
+  int8_t ISDS_enableSingleTapINT0(ISDS_state_t int0SingleTap);
+  int8_t ISDS_isSingleTapINT0Enabled(ISDS_state_t *int0SingleTap);
+  int8_t ISDS_enableInactivityStateINT0(ISDS_state_t int0InactivityState);
+  int8_t ISDS_isInactivityStateINT0Enabled(ISDS_state_t *int0InactivityState);
+
+  /* ISDS_MD2_CFG_REG */
+  int8_t ISDS_enableTiltINT1(ISDS_state_t int1Tilt);
+  int8_t ISDS_isTiltINT1Enabled(ISDS_state_t *int1Tilt);
+  int8_t ISDS_enable6dINT1(ISDS_state_t int16d);
+  int8_t ISDS_is6dINT1Enabled(ISDS_state_t *int16d);
+  int8_t ISDS_enableDoubleTapINT1(ISDS_state_t int1DoubleTap);
+  int8_t ISDS_isDoubleTapINT1Enabled(ISDS_state_t *int1DoubleTap);
+  int8_t ISDS_enableFreeFallINT1(ISDS_state_t int1FreeFall);
+  int8_t ISDS_isFreeFallINT1Enabled(ISDS_state_t *int1FreeFall);
+  int8_t ISDS_enableWakeUpINT1(ISDS_state_t int1WakeUp);
+  int8_t ISDS_isWakeUpINT1Enabled(ISDS_state_t *int1WakeUp);
+  int8_t ISDS_enableSingleTapINT1(ISDS_state_t int1SingleTap);
+  int8_t ISDS_isSingleTapINT1Enabled(ISDS_state_t *int1SingleTap);
+  int8_t ISDS_enableInactivityStateINT1(ISDS_state_t int1InactivityState);
+  int8_t ISDS_isInactivityStateINT1Enabled(ISDS_state_t *int1InactivityState);
+
+  /* ISDS_TIMESTAMP#_REG */
+  int8_t ISDS_getTimestamp(uint32_t *timestamp);
+  int8_t ISDS_resetTimestampCounter();
+
+  /* ISDS_#_OFS_USR_REG */
+  int8_t ISDS_setOffsetValueX(int8_t offsetValueXAxis);
+  int8_t ISDS_getOffsetValueX(int8_t *offsetValueXAxis);
+  int8_t ISDS_setOffsetValueY(int8_t offsetValueYAxis);
+  int8_t ISDS_getOffsetValueY(int8_t *offsetValueYAxis);
+  int8_t ISDS_setOffsetValueZ(int8_t offsetValueZAxis);
+  int8_t ISDS_getOffsetValueZ(int8_t *offsetValueZAxis);
+
+  /* ISDS_FIFO_DATA_OUT_L_REG */
+  /* ISDS_FIFO_DATA_OUT_H_REG */
+  int8_t ISDS_getFifoData(uint16_t numSamples, uint16_t *fifoData);
+
+  /* Gyroscope output */
+#ifdef WE_USE_FLOAT
+  int8_t ISDS_getAngularRateX_float(float *xRate);
+  int8_t ISDS_getAngularRateY_float(float *yRate);
+  int8_t ISDS_getAngularRateZ_float(float *zRate);
+  int8_t ISDS_getAngularRates_float(float *xRate, float *yRate, float *zRate);
+#else
+  #warning "WSEN_ISDS sensor driver: Float support is turned off by default. Define WE_USE_FLOAT to enable float support."
+#endif /* WE_USE_FLOAT */
+  int8_t ISDS_getAngularRateX_int(int32_t *xRate);
+  int8_t ISDS_getAngularRateY_int(int32_t *yRate);
+  int8_t ISDS_getAngularRateZ_int(int32_t *zRate);
+  int8_t ISDS_getAngularRates_int(int32_t *xRate, int32_t *yRate, int32_t *zRate);
+  int8_t ISDS_getRawAngularRateX(int16_t *xRawRate);
+  int8_t ISDS_getRawAngularRateY(int16_t *yRawRate);
+  int8_t ISDS_getRawAngularRateZ(int16_t *zRawRate);
+  int8_t ISDS_getRawAngularRates(int16_t *xRawRate, int16_t *yRawRate, int16_t *zRawRate);
+
+  /* Accelerometer output */
+#ifdef WE_USE_FLOAT
+  int8_t ISDS_getAccelerationX_float(float *xAcc);
+  int8_t ISDS_getAccelerationY_float(float *yAcc);
+  int8_t ISDS_getAccelerationZ_float(float *zAcc);
+  int8_t ISDS_getAccelerations_float(float *xAcc, float *yAcc, float *zAcc);
+#endif /* WE_USE_FLOAT */
+  int8_t ISDS_getAccelerationX_int(int16_t *xAcc);
+  int8_t ISDS_getAccelerationY_int(int16_t *yAcc);
+  int8_t ISDS_getAccelerationZ_int(int16_t *zAcc);
+  int8_t ISDS_getAccelerations_int(int16_t *xAcc, int16_t *yAcc, int16_t *zAcc);
+  int8_t ISDS_getRawAccelerationX(int16_t *xRawAcc);
+  int8_t ISDS_getRawAccelerationY(int16_t *yRawAcc);
+  int8_t ISDS_getRawAccelerationZ(int16_t *zRawAcc);
+  int8_t ISDS_getRawAccelerations(int16_t *xRawAcc, int16_t *yRawAcc, int16_t *zRawAcc);
+
+  /* Temperature sensor output */
+#ifdef WE_USE_FLOAT
+  int8_t ISDS_getTemperature_float(float *temperature);
+#endif /* WE_USE_FLOAT */
+  int8_t ISDS_getTemperature_int(int16_t *temperature);
+  int8_t ISDS_getRawTemperature(int16_t *temperature);
+
+
+#ifdef WE_USE_FLOAT
+  float ISDS_convertAcceleration_float(int16_t acc, ISDS_accFullScale_t fullScale);
+  float ISDS_convertAccelerationFs2g_float(int16_t acc);
+  float ISDS_convertAccelerationFs4g_float(int16_t acc);
+  float ISDS_convertAccelerationFs8g_float(int16_t acc);
+  float ISDS_convertAccelerationFs16g_float(int16_t acc);
+
+  float ISDS_convertAngularRate_float(int16_t rate, ISDS_gyroFullScale_t fullScale);
+  float ISDS_convertAngularRateFs125dps_float(int16_t rate);
+  float ISDS_convertAngularRateFs250dps_float(int16_t rate);
+  float ISDS_convertAngularRateFs500dps_float(int16_t rate);
+  float ISDS_convertAngularRateFs1000dps_float(int16_t rate);
+  float ISDS_convertAngularRateFs2000dps_float(int16_t rate);
+
+  float ISDS_convertTemperature_float(int16_t temperature);
+#endif /* WE_USE_FLOAT */
+
+  int16_t ISDS_convertAcceleration_int(int16_t acc, ISDS_accFullScale_t fullScale);
+  int16_t ISDS_convertAccelerationFs2g_int(int16_t acc);
+  int16_t ISDS_convertAccelerationFs4g_int(int16_t acc);
+  int16_t ISDS_convertAccelerationFs8g_int(int16_t acc);
+  int16_t ISDS_convertAccelerationFs16g_int(int16_t acc);
+
+  int32_t ISDS_convertAngularRate_int(int16_t rate, ISDS_gyroFullScale_t fullScale);
+  int32_t ISDS_convertAngularRateFs125dps_int(int16_t rate);
+  int32_t ISDS_convertAngularRateFs250dps_int(int16_t rate);
+  int32_t ISDS_convertAngularRateFs500dps_int(int16_t rate);
+  int32_t ISDS_convertAngularRateFs1000dps_int(int16_t rate);
+  int32_t ISDS_convertAngularRateFs2000dps_int(int16_t rate);
+
+  int16_t ISDS_convertTemperature_int(int16_t temperature);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _WSEN_ISDS_H */

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_pins.h
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_pins.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#define PIN_SDA           9
+#define PIN_SCL          18
+#define PIN_RGB          12
+#define PIN_LED          21
+#define PIN_IR           11 
+#define PIN_BLASTER_LINK 10
+#define PIN_BUZZER       46
+#define PIN_BATTERY_PIN  13
+
+#define TFCARD_CS_PIN    14
+
+#define CHANNEL_BUZZER 0
+
+// Following pins are not available on badge 2022, use Fri3dBadge_Joystick API for compatibility
+#define PIN_JOYSTICK_X    1
+#define PIN_JOYSTICK_Y    3
+

--- a/examples/platformio basic examples/hardware_test/lib/README
+++ b/examples/platformio basic examples/hardware_test/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in a an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/examples/platformio basic examples/hardware_test/platformio.ini
+++ b/examples/platformio basic examples/hardware_test/platformio.ini
@@ -1,0 +1,50 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:fri3dbadge2024]
+platform = espressif32@6.6.0
+board = esp32-s3-devkitc-1
+# Configure options for the N16R8V variant
+board_build.arduino.memory_type = qio_opi 
+board_build.partitions = default_16MB.csv
+board_upload.flash_size = 16MB
+framework = arduino
+monitor_speed = 115200
+lib_deps = 
+    fastled/FastLED@3.7.0
+    crankyoldgit/IRremoteESP8266@2.8.6
+    bodmer/TFT_eSPI@2.5.43
+
+build_flags =
+    -D BOARD_HAS_PSRAM 
+    -D ARDUINO_USB_MODE=1 
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+
+    -D USER_SETUP_LOADED
+	-D ST7789_DRIVER
+	-D TFT_RGB_ORDER=TFT_BGR # swap red and blue byte order
+	-D TFT_INVERSION_OFF
+	-D TFT_WIDTH=296  ;setting these will init the eSPI lib with correct dimensions
+	-D TFT_HEIGHT=240 ;setting these will init the eSPI lib with correct dimensions
+	-D TFT_MISO=8
+	-D TFT_MOSI=6
+	-D TFT_SCLK=7
+	-D TFT_CS=5
+	-D TFT_DC=4
+	-D TFT_RST=48
+	-D LOAD_GLCD=1
+	-D LOAD_FONT2
+	-D LOAD_FONT4
+	-D LOAD_FONT6
+	-D LOAD_FONT7
+	-D LOAD_FONT8
+	-D LOAD_GFXFF
+	-D SMOOTH_FONT
+	-D SPI_FREQUENCY=80000000

--- a/examples/platformio basic examples/hardware_test/src/main.cpp
+++ b/examples/platformio basic examples/hardware_test/src/main.cpp
@@ -1,0 +1,461 @@
+#include <Arduino.h>
+#include <TFT_eSPI.h>
+#include <Wire.h>
+#include <SPI.h>
+#include <FastLED.h>
+#include <IRrecv.h>
+#include <IRac.h> 
+#include <SD.h>
+
+#include "Fri3dBadge_Buzzer.h"
+#include "Fri3dBadge_pins.h"
+#include "Fri3dBadge_Joystick.h"
+#include "Fri3dBadge_Button.h"
+#include "Fri3dBadge_WSEN_ISDS.h"
+#include "Fri3dBadge24_battery_monitor.h"
+
+enum{
+  BUTTON_ID_A=0,
+  BUTTON_ID_B,
+  BUTTON_ID_X,
+  BUTTON_ID_Y,
+  BUTTON_ID_MENU,
+  BUTTON_ID_START,
+  BUTTON_ID_UP,
+  BUTTON_ID_DOWN,
+  BUTTON_ID_LEFT,
+  BUTTON_ID_RIGHT,
+
+  NUM_BUTTONS,
+};
+
+#define NUMLEDPIXELS 5
+CRGB leds[NUMLEDPIXELS];
+
+IRrecv irrecv(PIN_IR, 1024, 50, true);
+decode_results results;  // Somewhere to store the results
+
+TFT_eSPI tft = TFT_eSPI();
+
+TFT_eSprite joystick_sprite = TFT_eSprite(&tft);
+#define JOYSTICK_SPRITE_WIDTH  80
+#define JOYSTICK_SPRITE_HEIGHT 80
+
+int status_sd=0;
+
+Sensor_ISDS imu;
+
+TFT_eSprite horizon_sprite = TFT_eSprite(&tft);
+#define HORIZON_SPRITE_WIDTH  80
+#define HORIZON_SPRITE_HEIGHT 80
+
+TFT_eSprite battery_sprite = TFT_eSprite(&tft);
+#define BATTERY_SPRITE_WIDTH  50
+#define BATTERY_SPRITE_HEIGHT 36
+
+Fri3d_Button *buttons[NUM_BUTTONS]={
+  new Fri3d_Button (FRI3D_BUTTON_TYPE_DIGITAL,      39,25,INPUT_PULLUP,true),  // BUTTON_ID_A
+  new Fri3d_Button (FRI3D_BUTTON_TYPE_DIGITAL,      40,25,INPUT_PULLUP,true),  // BUTTON_ID_B
+  new Fri3d_Button (FRI3D_BUTTON_TYPE_DIGITAL,      38,25,INPUT_PULLUP,true),  // BUTTON_ID_X
+  new Fri3d_Button (FRI3D_BUTTON_TYPE_DIGITAL,      41,25,INPUT_PULLUP,true),  // BUTTON_ID_Y
+  new Fri3d_Button (FRI3D_BUTTON_TYPE_DIGITAL,      45,25,INPUT_PULLUP,true),  // BUTTON_ID_MENU
+  new Fri3d_Button (FRI3D_BUTTON_TYPE_DIGITAL,       0,25,INPUT,       true),  // BUTTON_ID_START, GPIO0 has fixed hardware pullup
+  new Fri3d_Button (FRI3D_BUTTON_TYPE_ANALOGUE_HIGH, 3, 0,INPUT,       false), // BUTTON_ID_UP
+  new Fri3d_Button (FRI3D_BUTTON_TYPE_ANALOGUE_LOW,  3, 0,INPUT,       false), // BUTTON_ID_DOWN
+  new Fri3d_Button (FRI3D_BUTTON_TYPE_ANALOGUE_LOW,  1, 0,INPUT,       false), // BUTTON_ID_LEFT
+  new Fri3d_Button (FRI3D_BUTTON_TYPE_ANALOGUE_HIGH, 1, 0,INPUT,       false), // BUTTON_ID_RIGHT
+};
+
+Fri3dBadge_Joystick joystick;
+Fri3dBadge_Buzzer buzzer;
+
+void buttons_init()
+{
+  for (int count=0; count<NUM_BUTTONS; ++count)
+  {
+    buttons[count]->begin();
+  } 
+}
+
+void buttons_update()
+{
+  for (int count=0; count<NUM_BUTTONS; ++count)
+  {
+     buttons[count]->read();
+  }
+}
+
+// Buzzer test functions
+void buzzer_test() {
+  buzzer.tone(500,200);
+  buzzer.setVolume(1);
+  buzzer.tone(200,200);
+  buzzer.noTone();
+}
+
+void i2c_scanner() {
+byte error, address;
+  int nDevices;
+
+  Wire.begin(PIN_SDA, PIN_SCL);
+  Serial.println("Scanning I2C ...");
+  Serial.print("SDA: ");
+  Serial.println(PIN_SDA);
+  Serial.print("SCL: ");
+  Serial.println(PIN_SCL);
+
+  nDevices = 0;
+  for (address = 1; address < 127; address++ )
+  {
+    // The i2c_scanner uses the return value of
+    // the Write.endTransmisstion to see if
+    // a device did acknowledge to the address.
+    Wire.beginTransmission(address);
+    error = Wire.endTransmission();
+
+    if (error == 0)
+    {
+      Serial.print("I2C device found at address 0x");
+      if (address < 16)
+        Serial.print("0");
+      Serial.print(address, HEX);
+      Serial.println("  !");
+
+      nDevices++;
+    }
+    else if (error == 4)
+    {
+      Serial.print("Unknow error at address 0x");
+      if (address < 16)
+        Serial.print("0");
+      Serial.println(address, HEX);
+    }
+  }
+  if (nDevices == 0)
+    Serial.println("No I2C devices found\n");
+  else
+    Serial.println("done\n");
+}
+
+void led_rgb_test() {
+  static int count=0; 
+  int color[3]={25,0,0};
+
+  FastLED.addLeds<WS2812, PIN_RGB, GRB>(leds, NUMLEDPIXELS);  
+  for (int i = 0; i < NUMLEDPIXELS; i++) {
+    leds[i] = CRGB(color[count%3], color[(count+1)%3], color[(count+2)%3]);
+  }
+  FastLED.show();
+  ++count;
+}
+
+void ir_init() {
+  irrecv.enableIRIn();  // Start the receiver
+}
+
+
+void ir_loop() {
+if (irrecv.decode(&results)) {
+    led_rgb_test();
+
+    // Display the basic output of what we found.
+    Serial.print(resultToHumanReadableBasic(&results));
+
+    // Display any extra A/C info if we have it.
+    String description = IRAcUtils::resultAcToString(&results);
+    if (description.length()) Serial.println(description);
+    yield();  // Feed the WDT as the text output can take a while to print.
+    // Output the results as source code
+    Serial.println(resultToSourceCode(&results));
+    Serial.println();    // Blank line between entries
+    yield();             // Feed the WDT (again)
+  }
+}
+
+void display_test()
+{
+  tft.init();
+  tft.writecommand(TFT_MADCTL);
+  tft.writedata(TFT_MAD_BGR | TFT_MAD_MV); //exchange red and blue bytes, and mirror x-coordinates
+  tft.fillScreen(TFT_BLACK);
+  tft.setCursor(tft.width()/2-90, 20);
+  tft.setTextColor(TFT_WHITE);
+  tft.setTextSize(2);
+  tft.println("Fri3d Badge 2024");
+}
+
+void buttonshow(int buttonid)
+{
+  Fri3d_Button *b = buttons[buttonid];
+  int x=0;
+  int y=0;
+  int w=0;
+  uint32_t col;
+  const char *buttonname="";
+  
+  switch(buttonid)
+  {
+    case BUTTON_ID_MENU:
+      x=40;
+      y=58;
+      w=70;
+      buttonname="MENU";
+      break;
+
+    case BUTTON_ID_START:
+      x=40;
+      y=80;
+      w=70;
+      buttonname="START";
+      break;
+
+    case BUTTON_ID_X:
+      x=200;
+      y=58;
+      w=30;
+      buttonname="X";
+      break;
+
+    case BUTTON_ID_Y:
+      x=160;
+      y=80;
+      w=30;
+      buttonname="Y";
+      break;
+
+    case BUTTON_ID_A:
+      x=240;
+      y=80;
+      w=30;
+      buttonname="A";
+      break;
+
+    case BUTTON_ID_B:
+      x=200;
+      y=92;
+      w=30;
+      buttonname="B";
+      break;
+  }
+  Serial.print(buttonname);
+  if (b->isPressed())
+  {
+    Serial.println(" pressed");
+    col = TFT_GREEN;
+  }
+  else {
+    Serial.println(" released");
+    col = TFT_BLACK;
+  }
+  if (x>0)
+  {
+   tft.fillRoundRect(x,y,w,18,2,col);
+   tft.drawRoundRect(x,y,w,18,2,TFT_WHITE);
+   tft.setCursor(x+5, y+2);
+   tft.setTextColor(TFT_WHITE);
+   tft.setTextSize(2);
+   tft.println(buttonname);
+  }
+}
+
+void buttonshowall()
+{
+  buttonshow(BUTTON_ID_MENU);
+  buttonshow(BUTTON_ID_START);
+  buttonshow(BUTTON_ID_A);
+  buttonshow(BUTTON_ID_B);
+  buttonshow(BUTTON_ID_X);
+  buttonshow(BUTTON_ID_Y);
+}
+
+void button_check(int buttonid)
+{
+  Fri3d_Button *b = buttons[buttonid];
+  if (b->wasPressed() || b->wasReleased())
+  {
+    buttonshow(buttonid);
+  }
+}
+
+void button_loop()
+{  
+  button_check(BUTTON_ID_MENU);
+  button_check(BUTTON_ID_START);
+  button_check(BUTTON_ID_A);
+  button_check(BUTTON_ID_B);
+  button_check(BUTTON_ID_X);
+  button_check(BUTTON_ID_Y);
+}
+
+void init_sd()
+{
+  SPIClass& spix = SPI;  // Create a class variable to hold the SPI class instance (default instance is SPI port 0 pins only)
+  spix = tft.getSPIinstance(); // Set to instance used by TFT library (may be SPI port 0 or 1)
+
+  if (!SD.begin(TFCARD_CS_PIN, spix, SPI_FREQUENCY)) {
+    Serial.println("Initialisatie van SD-kaart mislukt!");
+  }
+  else 
+  {
+     Serial.println("Initialisatie SD-kaart klaar.");
+     // hier mag geen tft commando
+     status_sd=1;
+  } 
+}
+
+void show_sd()
+{
+  if (status_sd)
+  {
+    tft.fillCircle(225,165,8,TFT_GREEN);
+  }
+  tft.drawCircle(225,165,8,TFT_WHITE);
+  tft.setCursor(240, 160);
+  tft.setTextColor(TFT_WHITE);
+  tft.setTextSize(2);
+  tft.println("SD");
+}
+
+void joystick_setup()
+{
+  joystick_sprite.createSprite(JOYSTICK_SPRITE_WIDTH, JOYSTICK_SPRITE_HEIGHT);
+}
+
+void joystick_show()
+{
+  const int radius = 10;
+  const int maxx  = JOYSTICK_SPRITE_WIDTH-2*radius;
+  const int maxy = JOYSTICK_SPRITE_HEIGHT-2*radius;
+  int x,y;
+
+  joystick_sprite.fillSprite(TFT_BLACK);
+  joystick.getXY(&x,&y);
+  // TODO map gebruiken 
+  int newx = radius + (x+2048) * maxx / 4096;
+  int newy = JOYSTICK_SPRITE_HEIGHT - ((y+2048) * maxy / 4096 + radius);
+  joystick_sprite.drawRect(0,0,JOYSTICK_SPRITE_WIDTH, JOYSTICK_SPRITE_HEIGHT,TFT_WHITE );
+  joystick_sprite.drawWideLine(JOYSTICK_SPRITE_WIDTH/2, JOYSTICK_SPRITE_HEIGHT/2, newx, newy, 5, TFT_DARKGREY, TFT_BLACK);
+  joystick_sprite.fillCircle(newx, newy, radius, TFT_GREEN);
+  joystick_sprite.pushSprite(30, 150);
+}
+
+void imu_setup()
+{
+  // Wire is al opgestard
+
+  imu.init(ISDS_ADDRESS_I2C_1);
+  imu.SW_RESET();
+  imu.select_ODR(2);
+  imu.set_Mode(2);
+
+  horizon_sprite.createSprite(HORIZON_SPRITE_WIDTH, HORIZON_SPRITE_HEIGHT);
+}
+
+double dotprod(int16_t x1, int16_t  y1, int16_t x2, int16_t y2)
+{
+  double res = (double) x1 * x2 + (double) y1 * y2;
+  return res;
+}
+
+void imu_show_horizon()
+{
+  int status;
+  int16_t acc_X, acc_Y, acc_Z;
+
+  horizon_sprite.fillSprite(TFT_BLACK);
+  horizon_sprite.drawRect(0,0,HORIZON_SPRITE_WIDTH, HORIZON_SPRITE_HEIGHT,TFT_WHITE );
+
+  status = imu.get_accelerations(&acc_X,&acc_Y,&acc_Z);
+  if (status == WE_FAIL) {
+    // cross
+    horizon_sprite.drawWideLine(0, 0, HORIZON_SPRITE_WIDTH, HORIZON_SPRITE_HEIGHT, 5, TFT_RED, TFT_BLACK);
+    horizon_sprite.drawWideLine(0, HORIZON_SPRITE_HEIGHT, HORIZON_SPRITE_WIDTH, 0, 5, TFT_RED, TFT_BLACK);
+  }
+  else {
+    //assumption: acc(X,Y,Z) is a vector that points down (to gravity)
+    //we then calculate angle with the vector that we want to see, i.e. perfect down, (-1000, 0, 0)
+    double mag_vector = sqrt((double)acc_X*acc_X + (double)acc_Y*acc_Y);
+    double cosangle = dotprod(-1000, 0, acc_X, acc_Y) / 1000.0 / mag_vector;
+    double sign = abs(acc_Y) / acc_Y;
+    double angle_radians = sign * (cosangle < 0? 2*PI - acos(-cosangle): acos(cosangle));
+    //given the angle, calculate #pixels we need to deviate from middle to draw our horizon:
+    //once the angle goes over 45, this doesn't work and we should actually calculate xdiff
+    float ydiff = sin(angle_radians) * HORIZON_SPRITE_WIDTH/2.0;
+
+    horizon_sprite.drawWideLine(0, HORIZON_SPRITE_HEIGHT/2+ydiff, HORIZON_SPRITE_WIDTH, HORIZON_SPRITE_HEIGHT/2-ydiff, 5, TFT_GREEN, TFT_BLACK);
+  }
+  horizon_sprite.pushSprite(120, 150);
+}
+
+void led_init()
+{
+  pinMode(PIN_LED,OUTPUT);
+}
+
+void led_update()
+{
+  digitalWrite(PIN_LED,(millis() % 1000) > 500 ? true  : false);
+}
+
+
+void battery_sprite_setup()
+{
+  battery_sprite.createSprite(BATTERY_SPRITE_WIDTH, BATTERY_SPRITE_HEIGHT);
+  battery_sprite.setTextColor(TFT_WHITE);
+  battery_sprite.setTextSize(2);
+}
+
+void battery_sprite_show()
+{
+  uint16_t bat_raw;
+  uint8_t bat_percent;
+  static unsigned long next_show=millis();
+
+  if (millis()<next_show) return;
+
+  battery_sprite.fillSprite(TFT_BLACK);
+  bat_raw = Battery::read_raw();
+  bat_percent = Battery::raw_to_percent(bat_raw);
+  battery_sprite.setCursor(0, 2);
+  battery_sprite.print("BAT");
+  battery_sprite.setCursor(0, 20);
+  battery_sprite.printf("%d%%", bat_percent);
+  battery_sprite.pushSprite(217, 190);
+  next_show+=1000; // 1 second
+}
+
+
+void setup()
+{
+  Serial.begin(115200);
+
+  // delay(5000);
+  // Serial.println("Fri3d badge hardware test");
+  // Serial.print("My IDF Version is: ");
+  // Serial.println(esp_get_idf_version());
+
+  buttons_init(); 
+  buzzer_test();
+  i2c_scanner();
+  led_rgb_test();
+  led_init();
+  ir_init();
+  display_test();
+  init_sd(); // moet na display_test (want spi moet al begonnen zijn)
+  buttonshowall();
+  show_sd(); // mag dit onmiddellijk na init_sd ???
+  joystick_setup();
+  imu_setup();
+  battery_sprite_setup();
+}
+
+void loop()
+{
+  ir_loop();
+  led_update();
+  buttons_update();
+  button_loop();
+  joystick_show();
+  imu_show_horizon();
+  battery_sprite_show();
+}


### PR DESCRIPTION
This is an example that integrates hardware tests for all components on the badge 2024 itself:
- beep on startup
- button test
- joystick test
- accelero test
- show battery voltage
- SD card: show if a card is available
- led test
- IR test : led color change

Known issue:
- crashes on 6.7.0
- too much code duplication, code of this github still needs to be reorganised as a library (time ...)