### PR TITLE
PlatformIO improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To work with peripherals like the display etc. on the badge, you will need insta
 Following settings can be used. Write following lines of code in platformio.ini
 
 ```
-platform = espressif32@^6.3.2
+platform = espressif32@6.6.0
 board = esp32-s3-devkitc-1
 
 ; Configure options for the N16R8V variant

--- a/examples/platformio basic examples/I2C_scanner/platformio.ini
+++ b/examples/platformio basic examples/I2C_scanner/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:fri3dbadge2024]
-platform = espressif32@^6.3.2
+platform = espressif32@6.6.0
 board = esp32-s3-devkitc-1
 ; Configure options for the N16R8V variant
 board_build.arduino.memory_type = qio_opi 

--- a/examples/platformio basic examples/IRsignals/platformio.ini
+++ b/examples/platformio basic examples/IRsignals/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32-s3-devkitc-1]
-platform = espressif32
+platform = espressif32@6.6.0
 board = esp32-s3-devkitc-1
 framework = arduino
 lib_deps = crankyoldgit/IRremoteESP8266@^2.8.6

--- a/examples/platformio basic examples/accelero_gyro/platformio.ini
+++ b/examples/platformio basic examples/accelero_gyro/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32-s3-devkitm-1]
-platform = espressif32
+platform = espressif32@6.6.0
 board = esp32-s3-devkitm-1
 framework = arduino
 # Configure options for the N16R8V variant

--- a/examples/platformio basic examples/blaster_v1_test/platformio.ini
+++ b/examples/platformio basic examples/blaster_v1_test/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32-s3-devkitm-1]
-platform = espressif32
+platform = espressif32@6.6.0
 framework = arduino
 
 ; Configure options for the N16R8V variant

--- a/examples/platformio basic examples/buttons/platformio.ini
+++ b/examples/platformio basic examples/buttons/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:fri3dbadge2024]
-platform = espressif32@^6.3.2
+platform = espressif32@6.6.0
 board = esp32-s3-devkitc-1
 
 ; Configure options for the N16R8V variant

--- a/examples/platformio basic examples/buzzer/platformio.ini
+++ b/examples/platformio basic examples/buzzer/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32-s3-devkitc-1]
-platform = espressif32
+platform = espressif32@6.6.0
 board = esp32-s3-devkitc-1
 framework = arduino
 # Configure options for the N16R8V variant

--- a/examples/platformio basic examples/buzzer/src/main.cpp
+++ b/examples/platformio basic examples/buzzer/src/main.cpp
@@ -1,21 +1,6 @@
 #include <Arduino.h>
 
 #define SPEAKER_PIN 46
-const int CHANNEL = 0;
-
-void ArduinoCuckoo();
-void ESP32WolfWhistle();
-
-void setup() {
-}
-
-void loop() {
-  //ArduinoCuckoo();
-  //delay(random(1000, 30000));
-
-  ESP32WolfWhistle();
-  delay(random(1000, 30000));
-}
 
 void ArduinoCuckoo()
 {
@@ -31,31 +16,11 @@ void ArduinoCuckoo()
   delay(2000);
 }
 
-//this only works for ESP32 in Arduino-compatible mode:
-void ESP32WolfWhistle()
-{
-  ledcSetup( CHANNEL, 3000, 8 );
-  ledcWrite( CHANNEL, 0 ); //volume on channel 0 to 0
-  ledcAttachPin(SPEAKER_PIN, CHANNEL); //link speaker pin to channel 0
+void setup() {
+  pinMode(SPEAKER_PIN, OUTPUT);
+}
 
-  ledcWrite(CHANNEL, 50); //volume 50%
-  for (int f=500; f<1400; f+=50) {
-    ledcWriteTone(CHANNEL, f);
-    delay(10);
-  }
-  
-  ledcWrite(CHANNEL, 0); //silence
-  delay(300);
-
-  ledcWrite(CHANNEL, 50); //volume 50%
-  for (int f=500; f<1400; f+=50) {
-    ledcWriteTone(CHANNEL, f);
-    delay(10);
-  }
-  for (int f=1400; f>500; f-=50) {
-    ledcWriteTone(CHANNEL, f);
-    delay(10);
-  }
-
-  ledcWrite(CHANNEL, 0); //silence
+void loop() {
+  ArduinoCuckoo();
+  delay(1000);
 }

--- a/examples/platformio basic examples/display_adafruit_gfx_hello_world/platformio.ini
+++ b/examples/platformio basic examples/display_adafruit_gfx_hello_world/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:fri3dbadge2024]
-platform = espressif32@^6.3.1
+platform = espressif32@6.6.0
 board = esp32-s3-devkitc-1
 ; Configure options for the N16R8V variant
 board_build.arduino.memory_type = qio_opi 

--- a/examples/platformio basic examples/display_lovyangfx_hello_world/platformio.ini
+++ b/examples/platformio basic examples/display_lovyangfx_hello_world/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:fri3dbadge2024]
-platform = espressif32@^6.3.2
+platform = espressif32@6.6.0
 board = esp32-s3-devkitc-1
 ; Configure options for the N16R8V variant
 board_build.arduino.memory_type = qio_opi 

--- a/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_Button.h
+++ b/examples/platformio basic examples/hardware_test/lib/Fri3dBadge2024/src/Fri3dBadge_Button.h
@@ -31,7 +31,13 @@ class Fri3d_Button
         // puEnable true to enable the AVR internal pullup resistor (default true)
         // invert   true to interpret a low logic level as pressed (default true)
         Fri3d_Button(Fri3DButton_type buttontype, uint8_t pin, uint32_t dbTime=25, uint8_t mode=INPUT_PULLUP, uint8_t invert=true)
-            : m_buttontype(buttontype), m_pin(pin), m_dbTime(dbTime), m_mode(mode), m_invert(invert) {}
+        {
+             m_buttontype = buttontype;
+             m_pin = pin;
+             m_dbTime = dbTime;
+             m_mode = mode;
+             m_invert = invert;
+        }
 
         // Initialize a Button object
         void begin();

--- a/examples/platformio basic examples/led_fastled_blink/platformio.ini
+++ b/examples/platformio basic examples/led_fastled_blink/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:fri3dbadge2024]
-platform = espressif32@^6.3.2
+platform = espressif32@6.6.0
 board = esp32-s3-devkitc-1
 # Configure options for the N16R8V variant
 board_build.arduino.memory_type = qio_opi 

--- a/examples/platformio basic examples/sdcard/platformio.ini
+++ b/examples/platformio basic examples/sdcard/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32-s3-devkitc-1]
-platform = espressif32@^6.3.2
+platform = espressif32@6.6.0
 framework = arduino
 
 board = esp32-s3-devkitc-1

--- a/examples/platformio basic examples/serial_port_hello_world/platformio.ini
+++ b/examples/platformio basic examples/serial_port_hello_world/platformio.ini
@@ -10,7 +10,7 @@
 
 
 [env:fri3dbadge2024]
-platform = espressif32@^6.3.2
+platform = espressif32@6.6.0
 board = esp32-s3-devkitc-1
 # Configure options for the N16R8V variant
 board_build.arduino.memory_type = qio_opi 

--- a/examples/platformio basic examples/usb_hid_keyboard/platformio.ini
+++ b/examples/platformio basic examples/usb_hid_keyboard/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:fri3dbadge2024]
-platform = espressif32@^6.5.0
+platform = espressif32@6.6.0
 board = esp32-s3-devkitc-1
 # Configure options for the N16R8V variant
 board_build.arduino.memory_type = qio_opi 

--- a/examples/platformio communicator/I2S_speaker_ESP8266Audio_RTTTL/platformio.ini
+++ b/examples/platformio communicator/I2S_speaker_ESP8266Audio_RTTTL/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:fri3dbadge2024]
-platform = espressif32@6.3.1
+platform = espressif32@6.6.0
 board = esp32-s3-devkitc-1
 ; Configure options for the N16R8V variant
 board_build.arduino.memory_type = qio_opi 

--- a/examples/platformio communicator/esp32-play-mp3-demo/platformio.ini
+++ b/examples/platformio communicator/esp32-play-mp3-demo/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:fri3dbadge2024]
-platform = espressif32
+platform = espressif32@6.6.0
 board = esp32-s3-devkitc-1
 ; Configure options for the N16R8V variant
 board_build.arduino.memory_type = qio_opi 


### PR DESCRIPTION
Wat hebben we geleerd op fri3d camp?
1) definieer core met unieke versie: espressif32@6.6.0
2) Gebruik pinmode vooraleer Tone. En laat ledc-xxx functies voor buzzer gewoon weg
3) 1 Laptop had problemen met variable initialisatie van buttons klasse. rara wiens?

Dank u, Piet.